### PR TITLE
Add hyperlinks to structs in documentation and format code with cargo fmt

### DIFF
--- a/src/codec/shake_codec.rs
+++ b/src/codec/shake_codec.rs
@@ -1,6 +1,6 @@
 //! Implementation of a Fiat-Shamir codec using SHAKE128
 //!
-//! This module defines `ShakeCodec`, a concrete implementation of the `Codec`
+//! This module defines [`ShakeCodec`], a concrete implementation of the [`Codec`]
 //! trait. It uses the SHAKE128 extendable output function (XOF) from the Keccak family
 //! to generate Fiat-Shamir challenges for Sigma protocols.
 //!
@@ -8,7 +8,7 @@
 //! and produces scalar challenges by squeezing bytes from the hash state.
 //!
 //! # Usage
-//! - The prover and verifier absorb the same messages into identical `ShakeCodec` instances.
+//! - The prover and verifier absorb the same messages into identical [`ShakeCodec`] instances.
 //! - The prover and the verifier then squeeze the hash to generate a challenge scalar for the protocol. The verifier can check that the prover used the challenge output by the codec because he owns an identical codec.
 
 use ff::PrimeField;

--- a/src/codec/trait.rs
+++ b/src/codec/trait.rs
@@ -1,6 +1,6 @@
 //! Codec Trait
 //!
-//! This module defines the `Codec` trait, a generic interface to manage codecs of a protocol execution.
+//! This module defines the [`Codec`] trait, a generic interface to manage codecs of a protocol execution.
 
 pub trait DuplexSpongeInterface {
     fn new(iv: &[u8]) -> Self;
@@ -17,7 +17,7 @@ pub trait DuplexSpongeInterface {
 /// The output is deterministic for a given set of input. Thus, both Prover and Verifier can generate the codec on their sides and ensure the same inputs have been used in both side of the protocol.
 ///
 /// ## Minimal Implementation
-/// Types implementing `Codec` must define:
+/// Types implementing [`Codec`] must define:
 /// - `new`
 /// - `prover_message`
 /// - `verifier_challenge`

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,8 +6,8 @@
 //! These errors include:
 //! - Verification failures (e.g., when a proof does not verify correctly).
 //! - Mismatched parameters during batch verification.
-//! - Not implemented methods
-//! - Group element/scalar serialization failed
+//! - Unimplemented methods.
+//! - Group element or scalar serialization failures.
 use thiserror::Error;
 /// An error during proving or verification, such as a verification failure.
 #[derive(Debug, Error)]
@@ -15,16 +15,16 @@ pub enum ProofError {
     /// Something is wrong with the proof, causing a verification failure.
     #[error("Verification failed.")]
     VerificationFailure,
-    /// Occurs during batch verification if the batch parameters do not have the right size.
+    /// Indicates a mismatch in parameter sizes during batch verification.
     #[error("Mismatched parameter sizes for batch verification.")]
     ProofSizeMismatch,
-    /// Occurs when a feature is not implemented yet.
-    #[error("The method is not yet implemented for this struct")]
+    /// Occurs when a feature has not been implemented yet.
+    #[error("The method is not yet implemented for this struct.")]
     NotImplemented(&'static str),
-    /// Serialization of a group element/scalar failed
-    #[error("Serialization of a group element/scalar failed")]
+    /// Serialization of a group element/scalar has failed.
+    #[error("Serialization of a group element/scalar failed.")]
     GroupSerializationFailure,
-    /// Other error
+    /// Other error.
     #[error("Other")]
     Other,
 }

--- a/src/fiat_shamir.rs
+++ b/src/fiat_shamir.rs
@@ -1,6 +1,6 @@
 //! Fiat-Shamir transformation for Sigma protocols.
 //!
-//! This module defines `NISigmaProtocol`, a generic non-interactive Sigma protocol wrapper,
+//! This module defines [`NISigmaProtocol`], a generic non-interactive Sigma protocol wrapper,
 //! based on applying the Fiat-Shamir heuristic using a codec.
 //!
 //! It transforms an interactive Sigma protocol into a non-interactive one,
@@ -9,9 +9,9 @@
 //!
 //! # Usage
 //! This struct is generic over:
-//! - `P`: the underlying Sigma protocol (`SigmaProtocol` trait).
-//! - `C`: the codec (`Codec` trait).
-//! - `G`: the group used for commitments and operations (`Group` trait).
+//! - `P`: the underlying Sigma protocol ([`SigmaProtocol`] trait).
+//! - `C`: the codec ([`Codec`] trait).
+//! - `G`: the group used for commitments and operations ([`Group`] trait).
 
 use crate::{codec::Codec, CompactProtocol, ProofError, SigmaProtocol};
 
@@ -26,7 +26,7 @@ type Transcript<P> = (
 
 /// A Fiat-Shamir transformation of a Sigma protocol into a non-interactive proof.
 ///
-/// `NISigmaProtocol` wraps an interactive Sigma protocol `P`
+/// [`NISigmaProtocol`] wraps an interactive Sigma protocol `P`
 /// and a hash-based codec `C`, to produce non-interactive proofs.
 ///
 /// It manages the domain separation, codec reset,
@@ -54,14 +54,14 @@ where
     P: SigmaProtocol<Commitment = Vec<G>, Challenge = <G as Group>::Scalar>,
     C: Codec<Challenge = <G as Group>::Scalar> + Clone,
 {
-    /// Constructs a new `NISigmaProtocol` instance.
+    /// Constructs a new [`NISigmaProtocol`] instance.
     ///
     /// # Parameters
     /// - `iv`: Domain separation tag for the hash function (e.g., protocol name or context).
     /// - `instance`: An instance of the interactive Sigma protocol.
     ///
     /// # Returns
-    /// A new `NISigmaProtocol` that can generate and verify non-interactive proofs.
+    /// A new [`NISigmaProtocol`] that can generate and verify non-interactive proofs.
     pub fn new(iv: &[u8], instance: P) -> Self {
         let hash_state = C::new(iv);
         Self {

--- a/src/fiat_shamir.rs
+++ b/src/fiat_shamir.rs
@@ -120,7 +120,7 @@ where
     /// # Returns
     /// - `Ok(())` if the proof is valid.
     /// - `Err(ProofError::VerificationFailure)` if the challenge is invalid or the response fails to verify.
-    /// 
+    ///
     /// # Errors
     /// - Returns `ProofError::VerificationFailure` if:
     ///   - The challenge doesn't match the recomputed one from the commitment.
@@ -177,7 +177,7 @@ where
     /// # Returns
     /// - `Ok(())` if the proof is valid.
     /// - `Err(ProofError)` if deserialization or verification fails.
-    /// 
+    ///
     /// # Errors
     /// - Returns `ProofError::VerificationFailure` if:
     ///   - The challenge doesn't match the recomputed one from the commitment.
@@ -241,7 +241,7 @@ where
     /// # Returns
     /// - `Ok(())` if the proof is valid.
     /// - `Err(ProofError)` if deserialization or verification fails.
-    /// 
+    ///
     /// # Errors
     /// - Returns `ProofError::VerificationFailure` if:
     ///   - Deserialization fails.

--- a/src/fiat_shamir.rs
+++ b/src/fiat_shamir.rs
@@ -87,7 +87,6 @@ where
     ///
     /// # Panics
     /// Panics if local verification fails.
-
     pub fn prove(
         &mut self,
         witness: &P::Witness,
@@ -182,7 +181,6 @@ where
     /// - Returns `ProofError::VerificationFailure` if:
     ///   - The challenge doesn't match the recomputed one from the commitment.
     ///   - The response fails verification under the Sigma protocol.
-
     pub fn verify_batchable(&mut self, proof: &[u8]) -> Result<(), ProofError> {
         let (commitment, response) = self.sigmap.deserialize_batchable(proof).unwrap();
 

--- a/src/group_morphism.rs
+++ b/src/group_morphism.rs
@@ -4,13 +4,16 @@
 //! supporting sigma protocols over group-based statements (e.g., discrete logarithms, DLEQ proofs). See Maurer09.
 //!
 //! It includes:
-//! - `LinearCombination`: a sparse representation of scalar multiplication relations
-//! - `Morphism`: a collection of linear combinations acting on group elements
-//! - `GroupMorphismPreimage`: a higher-level structure managing morphisms and their associated images
+//! - [`LinearCombination`]: a sparse representation of scalar multiplication relations
+//! - [`Morphism`]: a collection of linear combinations acting on group elements
+//! - [`GroupMorphismPreimage`]: a higher-level structure managing morphisms and their associated images
 
 use group::{Group, GroupEncoding};
 use std::iter;
 
+/// A wrapper representing an index for a scalar variable.
+///
+/// Used to reference scalars in sparse linear combinations.
 #[derive(Copy, Clone)]
 pub struct ScalarVar(usize);
 
@@ -19,7 +22,9 @@ impl ScalarVar {
         self.0
     }
 }
-
+/// A wrapper representing an index for a group element (point).
+///
+/// Used to reference group elements in sparse linear combinations.
 #[derive(Copy, Clone)]
 pub struct PointVar(usize);
 
@@ -29,10 +34,14 @@ impl PointVar {
     }
 }
 
-/// A sparse linear combination of scalars and group elements.
+/// Represents a sparse linear combination of scalars and group elements.
 ///
-/// Stores indices into external lists of scalars and group elements.
-/// Used to define individual constraints inside a Morphism.
+/// For example, it can represent an equation like:
+/// `s_1 * P_1 + s_2 * P_2 + ... + s_n * P_n`
+///
+/// where `s_i` are scalars (referenced by `scalar_indices`) and `P_i` are group elements (referenced by `element_indices`).
+///
+/// The indices refer to external lists managed by the containing Morphism.
 pub struct LinearCombination {
     pub scalar_indices: Vec<ScalarVar>,
     pub element_indices: Vec<PointVar>,
@@ -44,13 +53,27 @@ pub struct LinearCombination {
 /// and evaluates by performing multi-scalar multiplications.
 #[derive(Default)]
 pub struct Morphism<G: Group> {
+    /// The set of linear combination constraints (equations).
     pub linear_combination: Vec<LinearCombination>,
+    /// The list of group elements referenced in the morphism.
     pub group_elements: Vec<G>,
+    /// The total number of scalar variables allocated.
     pub num_scalars: usize,
+    ///The total number of group elements allocated.
     pub num_elements: usize,
 }
 
 /// Perform a simple multi-scalar multiplication (MSM) over scalars and points.
+/// 
+/// Given slices of scalars and corresponding group elements (bases),
+/// returns the sum of each base multiplied by its scalar coefficient.
+///
+/// # Parameters
+/// - `scalars`: slice of scalar multipliers
+/// - `bases`: slice of group elements to be multiplied by the scalars
+///
+/// # Returns
+/// The group element result of the MSM.
 pub fn msm_pr<G: Group>(scalars: &[G::Scalar], bases: &[G]) -> G {
     let mut acc = G::identity();
     for (s, p) in scalars.iter().zip(bases.iter()) {
@@ -60,7 +83,11 @@ pub fn msm_pr<G: Group>(scalars: &[G::Scalar], bases: &[G]) -> G {
 }
 
 impl<G: Group> Morphism<G> {
-    /// Creates a new empty Morphism.
+    /// Creates a new empty `Morphism`.
+    ///
+    /// # Returns
+    /// A `Morphism` instance with empty linear combinations and group elements,
+    /// and zero allocated scalars and elements.
     pub fn new() -> Self {
         Self {
             linear_combination: Vec::new(),
@@ -70,19 +97,26 @@ impl<G: Group> Morphism<G> {
         }
     }
 
-    /// Adds a new linear combination constraint.
+    /// Adds a new linear combination constraint to the morphism.
+    ///
+    /// # Parameters
+    /// - `lc`: The `LinearCombination` to add.
     pub fn append(&mut self, lc: LinearCombination) {
         self.linear_combination.push(lc);
     }
 
-    /// Returns the number of constraint statements.
+    /// Returns the number of linear combination constraints.
     pub fn num_statements(&self) -> usize {
         self.linear_combination.len()
     }
 
-    /// Evaluate the Morphism given a set of scalar values.
+    /// Evaluates all linear combinations in the morphism with the provided scalars.
     ///
-    /// Computes all linear combinations using the provided scalars and returns their group outputs.
+    /// # Parameters
+    /// - `scalars`: A slice of scalar values corresponding to the scalar variables.
+    ///
+    /// # Returns
+    /// A vector of group elements, each being the result of evaluating one linear combination with the scalars.
     pub fn evaluate(&self, scalars: &[<G as Group>::Scalar]) -> Vec<G> {
         self.linear_combination
             .iter()
@@ -100,11 +134,14 @@ impl<G: Group> Morphism<G> {
     }
 }
 
-/// A wrapper struct coupling a Morphism and the corresponding expected image elements.
+/// A wrapper struct coupling a `Morphism` with the corresponding expected output (image) elements.
 ///
-/// Provides a higher-level API to build proof instances from sparse constraints. The equations are manipulated solely through 2 lists:
-/// - the index of a set of Group elements (maintained in Morphism)
-/// - the index of a set of scalars (provided as input for the execution)
+/// This structure represents the *preimage problem* for a group morphism: given a set of scalar inputs,
+/// determine whether their image under the morphism matches a target set of group elements.
+///
+/// Internally, the constraint system is defined through:
+/// - A list of group elements and linear equations (held in the `Morphism` field),
+/// - A list of `PointVar` indices (`image`) that specify the expected output for each constraint.
 #[derive(Default)]
 pub struct GroupMorphismPreimage<G>
 where
@@ -128,15 +165,16 @@ where
         }
     }
 
-    /// Computes the number of bytes needed when serializing all the current commitments.
+    /// Computes the total number of bytes required to serialize all current commitments.
     pub fn commit_bytes_len(&self) -> usize {
         let repr_len = <G::Repr as Default>::default().as_ref().len(); // size of encoded point
         self.morphism.num_statements() * repr_len // total size of a commit
     }
 
     /// Append a new equation relating scalars to group elements.
-    ///
-    /// `lhs` is the image, and `rhs` is a list of (scalar, element) pairs.
+    /// # Parameters
+    /// - `lhs`: The image group element variable (left-hand side of the equation).
+    /// - `rhs`: A slice of `(ScalarVar, PointVar)` pairs representing the linear combination on the right-hand side.
     pub fn append_equation(&mut self, lhs: PointVar, rhs: &[(ScalarVar, PointVar)]) {
         let lc = LinearCombination {
             scalar_indices: rhs.iter().map(|&(s, _)| s).collect(),
@@ -146,16 +184,26 @@ where
         self.image.push(lhs);
     }
 
-    /// Allocate space for `n` new scalars and return their ScalarVar.
+    /// Allocates space for `n` new scalar variables.
+    ///
+    /// # Parameters
+    /// - `n`: Number of scalar variables to allocate.
+    ///
+    /// # Returns
+    /// A vector of `ScalarVar` representing the newly allocated scalar indices.
     pub fn allocate_scalars(&mut self, n: usize) -> Vec<ScalarVar> {
         let start = self.morphism.num_scalars;
         self.morphism.num_scalars += n;
         (start..start + n).map(ScalarVar).collect()
     }
 
-    /// Allocate space for `n` new group elements and return their PointVar.
+   /// Allocates space for `n` new group elements, initialized to the identity element.
     ///
-    /// The allocated elements are initially set to the identity.
+    /// # Parameters
+    /// - `n`: Number of group elements to allocate.
+    ///
+    /// # Returns
+    /// A vector of `PointVar` representing the newly allocated group element indices.
     pub fn allocate_elements(&mut self, n: usize) -> Vec<PointVar> {
         let start = self.morphism.num_elements;
         self.morphism
@@ -166,14 +214,20 @@ where
         points
     }
 
-    /// Set the value of group elements at a given index, inside the list of allocated group elements.
+    /// Sets the values of group elements at specified indices.
+    ///
+    /// # Parameters
+    /// - `elements`: A slice of `(PointVar, G)` tuples specifying which elements to update and their new values.
     pub fn set_elements(&mut self, elements: &[(PointVar, G)]) {
         for &(i, elt) in elements {
             self.morphism.group_elements[i.0] = elt;
         }
     }
 
-    /// Return the group elements corresponding to the image indices.
+    /// Returns the current group elements corresponding to the image variables.
+    ///
+    /// # Returns
+    /// A vector of group elements (`Vec<G>`) representing the morphism's image.
     pub fn image(&self) -> Vec<G> {
         let mut result = Vec::new();
         for i in &self.image {

--- a/src/group_morphism.rs
+++ b/src/group_morphism.rs
@@ -9,7 +9,7 @@
 //! - [`GroupMorphismPreimage`]: a higher-level structure managing morphisms and their associated images
 
 use group::{Group, GroupEncoding};
-use std::iter;
+use std::iter::repeat_n;
 
 /// A wrapper representing an index for a scalar variable.
 ///
@@ -208,7 +208,7 @@ where
         let start = self.morphism.num_elements;
         self.morphism
             .group_elements
-            .extend(iter::repeat(G::identity()).take(n));
+            .extend(repeat_n(G::identity(), n));
         let points = (start..start + n).map(PointVar).collect::<Vec<_>>();
         self.morphism.num_elements += n;
         points

--- a/src/group_morphism.rs
+++ b/src/group_morphism.rs
@@ -83,10 +83,10 @@ pub fn msm_pr<G: Group>(scalars: &[G::Scalar], bases: &[G]) -> G {
 }
 
 impl<G: Group> Morphism<G> {
-    /// Creates a new empty `Morphism`.
+    /// Creates a new empty [`Morphism`].
     ///
     /// # Returns
-    /// A `Morphism` instance with empty linear combinations and group elements,
+    /// A [`Morphism`] instance with empty linear combinations and group elements,
     /// and zero allocated scalars and elements.
     pub fn new() -> Self {
         Self {
@@ -100,7 +100,7 @@ impl<G: Group> Morphism<G> {
     /// Adds a new linear combination constraint to the morphism.
     ///
     /// # Parameters
-    /// - `lc`: The `LinearCombination` to add.
+    /// - `lc`: The [`LinearCombination`] to add.
     pub fn append(&mut self, lc: LinearCombination) {
         self.linear_combination.push(lc);
     }
@@ -134,14 +134,14 @@ impl<G: Group> Morphism<G> {
     }
 }
 
-/// A wrapper struct coupling a `Morphism` with the corresponding expected output (image) elements.
+/// A wrapper struct coupling a [`Morphism`] with the corresponding expected output (image) elements.
 ///
 /// This structure represents the *preimage problem* for a group morphism: given a set of scalar inputs,
 /// determine whether their image under the morphism matches a target set of group elements.
 ///
 /// Internally, the constraint system is defined through:
-/// - A list of group elements and linear equations (held in the `Morphism` field),
-/// - A list of `PointVar` indices (`image`) that specify the expected output for each constraint.
+/// - A list of group elements and linear equations (held in the [`Morphism`] field),
+/// - A list of [`PointVar`] indices (`image`) that specify the expected output for each constraint.
 #[derive(Default)]
 pub struct GroupMorphismPreimage<G>
 where
@@ -190,7 +190,7 @@ where
     /// - `n`: Number of scalar variables to allocate.
     ///
     /// # Returns
-    /// A vector of `ScalarVar` representing the newly allocated scalar indices.
+    /// A vector of [`ScalarVar`] representing the newly allocated scalar indices.
     pub fn allocate_scalars(&mut self, n: usize) -> Vec<ScalarVar> {
         let start = self.morphism.num_scalars;
         self.morphism.num_scalars += n;
@@ -203,7 +203,7 @@ where
     /// - `n`: Number of group elements to allocate.
     ///
     /// # Returns
-    /// A vector of `PointVar` representing the newly allocated group element indices.
+    /// A vector of [`PointVar`] representing the newly allocated group element indices.
     pub fn allocate_elements(&mut self, n: usize) -> Vec<PointVar> {
         let start = self.morphism.num_elements;
         self.morphism

--- a/src/group_morphism.rs
+++ b/src/group_morphism.rs
@@ -64,7 +64,7 @@ pub struct Morphism<G: Group> {
 }
 
 /// Perform a simple multi-scalar multiplication (MSM) over scalars and points.
-/// 
+///
 /// Given slices of scalars and corresponding group elements (bases),
 /// returns the sum of each base multiplied by its scalar coefficient.
 ///
@@ -197,7 +197,7 @@ where
         (start..start + n).map(ScalarVar).collect()
     }
 
-   /// Allocates space for `n` new group elements, initialized to the identity element.
+    /// Allocates space for `n` new group elements, initialized to the identity element.
     ///
     /// # Parameters
     /// - `n`: Number of group elements to allocate.

--- a/src/group_serialization.rs
+++ b/src/group_serialization.rs
@@ -1,12 +1,33 @@
+//! Serialization and deserialization utilities for group elements and scalars.
+//!
+//! This module provides functions to convert group elements and scalars to and from
+//! byte representations using canonical encodings. 
+
 use ff::PrimeField;
 use group::{Group, GroupEncoding};
 
 use crate::ProofError;
 
+/// Serialize a group element into a byte vector.
+///
+/// # Inputs
+/// - `element`: A reference to the group element to serialize.
+///
+/// # Outputs
+/// - A `Vec<u8>` containing the canonical compressed byte representation of the element.
 pub fn serialize_element<G: Group + GroupEncoding>(element: &G) -> Vec<u8> {
     element.to_bytes().as_ref().to_vec()
 }
 
+/// Deserialize a byte slice into a group element.
+///
+/// # Parameters
+/// - `data`: A byte slice containing the serialized representation of the group element.
+///
+/// # Returns
+/// - `Ok(G)`: The deserialized group element if the input is valid.
+/// - `Err(ProofError::GroupSerializationFailure)`: If the byte slice length is incorrect or the data
+///   does not represent a valid group element.
 pub fn deserialize_element<G: Group + GroupEncoding>(data: &[u8]) -> Result<G, ProofError> {
     let element_len = G::Repr::default().as_ref().len();
     if data.len() != element_len {
@@ -24,12 +45,27 @@ pub fn deserialize_element<G: Group + GroupEncoding>(data: &[u8]) -> Result<G, P
     }
 }
 
+/// Serialize a scalar field element into a byte vector 
+///
+/// # Inputs
+/// - `scalar`: A reference to the scalar field element to serialize.
+///
+/// # Outputs
+/// - A `Vec<u8>` containing the scalar bytes in little-endian order.
 pub fn serialize_scalar<G: Group>(scalar: &G::Scalar) -> Vec<u8> {
     let mut scalar_bytes = scalar.to_repr().as_ref().to_vec();
     scalar_bytes.reverse();
     scalar_bytes
 }
-
+/// Deserialize a byte slice into a scalar field element.
+///
+/// # Parameters
+/// - `data`: A byte slice containing the serialized scalar in little-endian order.
+///
+/// # Returns
+/// - `Ok(G::Scalar)`: The deserialized scalar if the input is valid.
+/// - `Err(ProofError::GroupSerializationFailure)`: If the byte slice length is incorrect or the data
+///   does not represent a valid scalar.
 pub fn deserialize_scalar<G: Group>(data: &[u8]) -> Result<G::Scalar, ProofError> {
     let scalar_len = <<G as Group>::Scalar as PrimeField>::Repr::default()
         .as_ref()

--- a/src/group_serialization.rs
+++ b/src/group_serialization.rs
@@ -47,7 +47,7 @@ pub fn deserialize_element<G: Group + GroupEncoding>(data: &[u8]) -> Result<G, P
 
 /// Serialize a scalar field element into a byte vector 
 ///
-/// # Inputs
+/// # Parameters
 /// - `scalar`: A reference to the scalar field element to serialize.
 ///
 /// # Outputs

--- a/src/group_serialization.rs
+++ b/src/group_serialization.rs
@@ -1,7 +1,7 @@
 //! Serialization and deserialization utilities for group elements and scalars.
 //!
 //! This module provides functions to convert group elements and scalars to and from
-//! byte representations using canonical encodings. 
+//! byte representations using canonical encodings.
 
 use ff::PrimeField;
 use group::{Group, GroupEncoding};
@@ -45,7 +45,7 @@ pub fn deserialize_element<G: Group + GroupEncoding>(data: &[u8]) -> Result<G, P
     }
 }
 
-/// Serialize a scalar field element into a byte vector 
+/// Serialize a scalar field element into a byte vector
 ///
 /// # Parameters
 /// - `scalar`: A reference to the scalar field element to serialize.

--- a/src/proof_builder.rs
+++ b/src/proof_builder.rs
@@ -53,7 +53,7 @@ where
     /// `lhs = Σ (scalar_i * point_i)`
     ///
     /// # Parameters
-    /// - `lhs`: The `PointVar` index representing the left-hand group element.
+    /// - `lhs`: The [`PointVar`] index representing the left-hand group element.
     /// - `rhs`: A list of (scalar variable, point variable) tuples for the linear combination.
     pub fn append_equation(&mut self, lhs: PointVar, rhs: &[(ScalarVar, PointVar)]) {
         self.protocol.sigmap.append_equation(lhs, rhs);
@@ -61,14 +61,14 @@ where
 
     /// Allocates `n` scalar variables for use in the proof.
     ///
-    /// Returns a vector of `ScalarVar` indices.
+    /// Returns a vector of [`ScalarVar`] indices.
     pub fn allocate_scalars(&mut self, n: usize) -> Vec<ScalarVar> {
         self.protocol.sigmap.allocate_scalars(n)
     }
 
     /// Allocates `n` point variables (group elements) for use in the proof.
     ///
-    /// Returns a vector of `PointVar` indices.
+    /// Returns a vector of [`PointVar`] indices.
     pub fn allocate_elements(&mut self, n: usize) -> Vec<PointVar> {
         self.protocol.sigmap.allocate_elements(n)
     }

--- a/src/proof_builder.rs
+++ b/src/proof_builder.rs
@@ -1,4 +1,4 @@
-//! Proof Builder for Sigma Protocols
+//! # Proof Builder for Sigma Protocols
 //!
 //! This module defines the [`ProofBuilder`] struct, a high-level utility that simplifies
 //! the construction and interaction with zero-knowledge proofs based on Sigma protocols.
@@ -8,10 +8,10 @@
 //! relations over cryptographic groups.
 //!
 //! ## Features
-//! - Allocates scalar and point variables for constructing group equations
-//! - Appends equations representing statements to be proven
-//! - Supports element assignment to statement variables
-//! - Offers one-shot `prove` and `verify` methods
+//! - Allocates scalar and point variables for constructing group equations.
+//! - Appends equations representing statements to be proven.
+//! - Supports element assignment to statement variables.
+//! - Offers one-shot `prove` and `verify` methods.
 
 use group::{Group, GroupEncoding};
 use rand::{CryptoRng, RngCore};
@@ -53,8 +53,8 @@ where
     /// `lhs = Σ (scalar_i * point_i)`
     ///
     /// # Parameters
-    /// - `lhs`: The variable representing the left-hand group element
-    /// - `rhs`: A list of (scalar variable, point variable) tuples for the linear combination
+    /// - `lhs`: The `PointVar` index representing the left-hand group element.
+    /// - `rhs`: A list of (scalar variable, point variable) tuples for the linear combination.
     pub fn append_equation(&mut self, lhs: PointVar, rhs: &[(ScalarVar, PointVar)]) {
         self.protocol.sigmap.append_equation(lhs, rhs);
     }
@@ -76,7 +76,7 @@ where
     /// Assigns specific group elements to point variables (indices).
     ///
     /// # Parameters
-    /// - `elements`: A list of `(PointVar, GroupElement)` pairs
+    /// - `elements`: A list of `(PointVar, GroupElement)` pairs.
     pub fn set_elements(&mut self, elements: &[(PointVar, G)]) {
         self.protocol.sigmap.set_elements(elements);
     }
@@ -91,8 +91,8 @@ where
     /// Generates a non-interactive zero-knowledge proof for the current statement using the given witness.
     ///
     /// # Parameters
-    /// - `witness`: A list of scalars (one per allocated scalar variable)
-    /// - `rng`: A random number generator
+    /// - `witness`: A list of scalars (one per allocated scalar variable).
+    /// - `rng`: A random number generator.
     ///
     /// # Returns
     /// A serialized proof as a vector of bytes in batchable ('commitment', 'response') format.
@@ -108,7 +108,7 @@ where
     /// Verifies a serialized batchable proof against the current statement.
     ///
     /// # Parameters
-    /// - `proof`: A byte slice containing the serialized batchable proof
+    /// - `proof`: A byte slice containing the serialized batchable proof.
     ///
     /// # Returns
     /// `Ok(())` if the proof is valid, or a [`ProofError`] if verification fails.
@@ -119,8 +119,8 @@ where
     /// Generates a compact proof for the current statement using the given witness.
     ///
     /// # Parameters
-    /// - `witness`: A list of scalars (one per allocated scalar variable)
-    /// - `rng`: A random number generator
+    /// - `witness`: A list of scalars (one per allocated scalar variable).
+    /// - `rng`: A random number generator.
     ///
     /// # Returns
     /// A serialized proof as a vector of bytes in compact ('challenge', 'response') format.
@@ -136,7 +136,7 @@ where
     /// Verifies a serialized compact proof against the current statement.
     ///
     /// # Parameters
-    /// - `proof`: A byte slice containing the serialized compact proof
+    /// - `proof`: A byte slice containing the serialized compact proof.
     ///
     /// # Returns
     /// `Ok(())` if the proof is valid, or a [`ProofError`] if verification fails.

--- a/src/schnorr_protocol.rs
+++ b/src/schnorr_protocol.rs
@@ -18,7 +18,7 @@ use rand::{CryptoRng, RngCore};
 ///
 /// This implementation generalizes Schnorr’s discrete logarithm proof by using
 /// a [`GroupMorphismPreimage`], representing an abstract linear relation over the group.
-/// 
+///
 /// # Type Parameters
 /// - `G`: A cryptographic group implementing `Group` and `GroupEncoding`.
 #[derive(Default)]
@@ -172,18 +172,18 @@ where
         }
     }
 
-        /// Serializes the proof into a batchable format: commitments followed by responses.
-        ///
-        /// # Parameters
-        /// - `commitment`: A vector of group elements (typically sent in the first round).
-        /// - `_challenge`: The verifier’s challenge (omitted from batchable format).
-        /// - `response`: A vector of scalars forming the prover’s response.
-        ///
-        /// # Returns
-        /// - A byte vector representing the serialized batchable proof.
-        ///
-        /// # Errors
-        /// - `ProofError::Other` if the commitment or response length is incorrect.
+    /// Serializes the proof into a batchable format: commitments followed by responses.
+    ///
+    /// # Parameters
+    /// - `commitment`: A vector of group elements (typically sent in the first round).
+    /// - `_challenge`: The verifier’s challenge (omitted from batchable format).
+    /// - `response`: A vector of scalars forming the prover’s response.
+    ///
+    /// # Returns
+    /// - A byte vector representing the serialized batchable proof.
+    ///
+    /// # Errors
+    /// - `ProofError::Other` if the commitment or response length is incorrect.
 
     fn serialize_batchable(
         &self,
@@ -307,12 +307,12 @@ where
     /// - `_commitment`: Omitted in compact format (reconstructed during verification).
     /// - `challenge`: The challenge scalar.
     /// - `response`: The prover’s response.
-    /// 
+    ///
     /// # Returns
     /// - A byte vector representing the compact proof.
     ///
     /// # Errors
-/// - `ProofError::Other` if the response length does not match the expected number of scalars.
+    /// - `ProofError::Other` if the response length does not match the expected number of scalars.
     fn serialize_compact(
         &self,
         _commitment: &Self::Commitment,
@@ -342,7 +342,7 @@ where
     ///
     /// # Returns
     /// - A tuple `(challenge, response)`.
-    /// 
+    ///
     /// # Errors
     /// - `ProofError::ProofSizeMismatch` if the input data length does not match the expected size.
     /// - `ProofError::GroupSerializationFailure` if scalar deserialization fails.
@@ -384,11 +384,11 @@ where
     G: Group + GroupEncoding,
 {
     /// Simulates a valid transcript for a given challenge without a witness.
-    /// 
+    ///
     /// # Parameters
     /// - `challenge`: A scalar value representing the challenge.
     /// - `rng`: A cryptographically secure RNG.
-    /// 
+    ///
     /// # Returns
     /// - A commitment and response forming a valid proof for the given challenge.
     fn simulate_proof(

--- a/src/schnorr_protocol.rs
+++ b/src/schnorr_protocol.rs
@@ -9,7 +9,6 @@ use crate::{
     ScalarVar, SigmaProtocol, SigmaProtocolSimulator,
 };
 
-use core::iter;
 use ff::{Field, PrimeField};
 use group::{Group, GroupEncoding};
 use rand::{CryptoRng, RngCore};
@@ -20,7 +19,7 @@ use rand::{CryptoRng, RngCore};
 /// a [`GroupMorphismPreimage`], representing an abstract linear relation over the group.
 ///
 /// # Type Parameters
-/// - `G`: A cryptographic group implementing `Group` and `GroupEncoding`.
+/// - `G`: A cryptographic group implementing [`Group`] and [`GroupEncoding`].
 #[derive(Default)]
 pub struct SchnorrProtocol<G: Group + GroupEncoding>(GroupMorphismPreimage<G>);
 
@@ -89,7 +88,6 @@ where
     ///
     /// # Errors
     /// -`ProofError::Other` if the witness vector length is incorrect.
-
     fn prover_commit(
         &self,
         witness: &Self::Witness,
@@ -118,7 +116,6 @@ where
     ///
     /// # Errors
     /// - Returns `ProofError::Other` if the prover state vectors have incorrect lengths.
-
     fn prover_response(
         &self,
         state: Self::ProverState,
@@ -150,7 +147,6 @@ where
     /// -`Err(ProofError::VerificationFailure)` if the computed relation
     /// does not hold for the provided challenge and response, indicating proof invalidity.
     /// -`Err(ProofError::Other)` if the commitment or response length is incorrect.
-
     fn verifier(
         &self,
         commitment: &Self::Commitment,
@@ -184,7 +180,6 @@ where
     ///
     /// # Errors
     /// - `ProofError::Other` if the commitment or response length is incorrect.
-
     fn serialize_batchable(
         &self,
         commitment: &Self::Commitment,
@@ -225,7 +220,6 @@ where
     ///   expected for `commit_nb` commitments plus `response_nb` responses.
     /// - `ProofError::GroupSerializationFailure` if any group element or scalar fails to
     ///   deserialize (propagated from `deserialize_element` or `deserialize_scalar`).
-
     fn deserialize_batchable(
         &self,
         data: &[u8],
@@ -397,7 +391,8 @@ where
         rng: &mut (impl RngCore + CryptoRng),
     ) -> (Self::Commitment, Self::Response) {
         let mut response = Vec::new();
-        response.extend(iter::repeat(G::Scalar::random(rng)).take(self.scalars_nb()));
+        response.extend(std::iter::repeat_n(G::Scalar::random(rng), self.scalars_nb())
+);
         let commitment = self.get_commitment(challenge, &response).unwrap();
         (commitment, response)
     }

--- a/src/schnorr_protocol.rs
+++ b/src/schnorr_protocol.rs
@@ -14,9 +14,13 @@ use ff::{Field, PrimeField};
 use group::{Group, GroupEncoding};
 use rand::{CryptoRng, RngCore};
 
-/// A Schnorr protocol proving knowledge some discrete logarithm relation.
+/// A Schnorr protocol proving knowledge of a witness for a linear group relation.
 ///
-/// The specific proof instance is defined by a [`GroupMorphismPreimage`] over a group `G`.
+/// This implementation generalizes Schnorr’s discrete logarithm proof by using
+/// a [`GroupMorphismPreimage`], representing an abstract linear relation over the group.
+/// 
+/// # Type Parameters
+/// - `G`: A cryptographic group implementing `Group` and `GroupEncoding`.
 #[derive(Default)]
 pub struct SchnorrProtocol<G: Group + GroupEncoding>(GroupMorphismPreimage<G>);
 
@@ -72,7 +76,20 @@ where
     type Witness = Vec<<G as Group>::Scalar>;
     type Challenge = <G as Group>::Scalar;
 
-    /// Prover's first message: generates a random commitment based on random nonces.
+    /// Prover's first message: generates a commitment using random nonces.
+    ///
+    /// # Parameters
+    /// - `witness`: A vector of scalars that satisfy the morphism relation.
+    /// - `rng`: A cryptographically secure random number generator.
+    ///
+    /// # Returns
+    /// - A tuple containing:
+    ///     - The commitment (a vector of group elements).
+    ///     - The prover state (random nonces and witness) used to compute the response.
+    ///
+    /// # Errors
+    /// -`ProofError::Other` if the witness vector length is incorrect.
+
     fn prover_commit(
         &self,
         witness: &Self::Witness,
@@ -90,7 +107,18 @@ where
         Ok((commitment, prover_state))
     }
 
-    /// Prover's last message: computes the response to a given challenge.
+    /// Computes the prover's response (second message) using the challenge.
+    ///
+    /// # Parameters
+    /// - `state`: The prover state returned by `prover_commit`, typically containing randomness and witness components.
+    /// - `challenge`: The verifier's challenge scalar.
+    ///
+    /// # Returns
+    /// - A vector of scalars forming the prover's response.
+    ///
+    /// # Errors
+    /// - Returns `ProofError::Other` if the prover state vectors have incorrect lengths.
+
     fn prover_response(
         &self,
         state: Self::ProverState,
@@ -106,8 +134,23 @@ where
         }
         Ok(responses)
     }
+    /// Verifies the correctness of the proof.
+    ///
+    /// # Parameters
+    /// - `commitment`: The prover's commitment vector (group elements).
+    /// - `challenge`: The challenge scalar.
+    /// - `response`: The prover's response vector.
+    ///
+    /// # Returns
+    /// - `Ok(())` if the proof is valid.
+    /// - `Err(ProofError::VerificationFailure)` if the proof is invalid.
+    /// - `Err(ProofError::Other)` if the lengths of commitment or response do not match the expected counts.
+    ///
+    /// # Errors
+    /// -`Err(ProofError::VerificationFailure)` if the computed relation
+    /// does not hold for the provided challenge and response, indicating proof invalidity.
+    /// -`Err(ProofError::Other)` if the commitment or response length is incorrect.
 
-    /// Verifier checks that the provided response satisfies the verification equations.
     fn verifier(
         &self,
         commitment: &Self::Commitment,
@@ -129,7 +172,19 @@ where
         }
     }
 
-    /// Serializes the proof into a batchable (`commitment`, `response`) format for transmission.
+        /// Serializes the proof into a batchable format: commitments followed by responses.
+        ///
+        /// # Parameters
+        /// - `commitment`: A vector of group elements (typically sent in the first round).
+        /// - `_challenge`: The verifier’s challenge (omitted from batchable format).
+        /// - `response`: A vector of scalars forming the prover’s response.
+        ///
+        /// # Returns
+        /// - A byte vector representing the serialized batchable proof.
+        ///
+        /// # Errors
+        /// - `ProofError::Other` if the commitment or response length is incorrect.
+
     fn serialize_batchable(
         &self,
         commitment: &Self::Commitment,
@@ -155,7 +210,22 @@ where
         Ok(bytes)
     }
 
-    /// Deserializes a batchable proof format back into (`commitment`, `response`).
+    /// Deserializes a batchable proof into a commitment vector and response vector.
+    ///
+    /// # Parameters
+    /// - `data`: A byte slice containing the serialized proof.
+    ///
+    /// # Returns
+    /// - A tuple `(commitment, response)` where  
+    ///   * `commitment` is a vector of group elements (one per statement), and  
+    ///   * `response`   is a vector of scalars (one per witness).
+    ///
+    /// # Errors
+    /// - `ProofError::ProofSizeMismatch` if the input length is not the exact number of bytes
+    ///   expected for `commit_nb` commitments plus `response_nb` responses.
+    /// - `ProofError::GroupSerializationFailure` if any group element or scalar fails to
+    ///   deserialize (propagated from `deserialize_element` or `deserialize_scalar`).
+
     fn deserialize_batchable(
         &self,
         data: &[u8],
@@ -202,6 +272,17 @@ impl<G> CompactProtocol for SchnorrProtocol<G>
 where
     G: Group + GroupEncoding,
 {
+    /// Recomputes the commitment from the challenge and response (used in compact proofs).
+    ///
+    /// # Parameters
+    /// - `challenge`: The challenge scalar issued by the verifier or derived via Fiat–Shamir.
+    /// - `response`: The prover’s response vector.
+    ///
+    /// # Returns
+    /// - A vector of group elements representing the recomputed commitment (one per linear constraint).
+    ///
+    /// # Errors
+    /// - `ProofError::Other` if the response length does not match the expected number of scalars.
     fn get_commitment(
         &self,
         challenge: &Self::Challenge,
@@ -221,7 +302,17 @@ where
         Ok(commitment)
     }
 
-    /// Serializes the proof into a compact (`challenge`, `response`) format for transmission.
+    /// Serializes a compact transcript: challenge followed by responses.
+    /// # Parameters
+    /// - `_commitment`: Omitted in compact format (reconstructed during verification).
+    /// - `challenge`: The challenge scalar.
+    /// - `response`: The prover’s response.
+    /// 
+    /// # Returns
+    /// - A byte vector representing the compact proof.
+    ///
+    /// # Errors
+/// - `ProofError::Other` if the response length does not match the expected number of scalars.
     fn serialize_compact(
         &self,
         _commitment: &Self::Commitment,
@@ -244,7 +335,17 @@ where
         Ok(bytes)
     }
 
-    /// Deserializes a compact proof format back into (`challenge`, `response`).
+    /// Deserializes a compact proof into a challenge and response.
+    ///
+    /// # Parameters
+    /// - `data`: A byte slice encoding the compact proof.
+    ///
+    /// # Returns
+    /// - A tuple `(challenge, response)`.
+    /// 
+    /// # Errors
+    /// - `ProofError::ProofSizeMismatch` if the input data length does not match the expected size.
+    /// - `ProofError::GroupSerializationFailure` if scalar deserialization fails.
     fn deserialize_compact(
         &self,
         data: &[u8],
@@ -282,6 +383,14 @@ impl<G> SigmaProtocolSimulator for SchnorrProtocol<G>
 where
     G: Group + GroupEncoding,
 {
+    /// Simulates a valid transcript for a given challenge without a witness.
+    /// 
+    /// # Parameters
+    /// - `challenge`: A scalar value representing the challenge.
+    /// - `rng`: A cryptographically secure RNG.
+    /// 
+    /// # Returns
+    /// - A commitment and response forming a valid proof for the given challenge.
     fn simulate_proof(
         &self,
         challenge: &Self::Challenge,
@@ -293,6 +402,13 @@ where
         (commitment, response)
     }
 
+    /// Simulates a full proof transcript using a randomly generated challenge.
+    ///
+    /// # Parameters
+    /// - `rng`: A cryptographically secure RNG.
+    ///
+    /// # Returns
+    /// - A tuple `(commitment, challenge, response)` forming a valid proof.
     fn simulate_transcript(
         &self,
         rng: &mut (impl RngCore + CryptoRng),

--- a/src/schnorr_protocol.rs
+++ b/src/schnorr_protocol.rs
@@ -391,8 +391,10 @@ where
         rng: &mut (impl RngCore + CryptoRng),
     ) -> (Self::Commitment, Self::Response) {
         let mut response = Vec::new();
-        response.extend(std::iter::repeat_n(G::Scalar::random(rng), self.scalars_nb())
-);
+        response.extend(std::iter::repeat_n(
+            G::Scalar::random(rng),
+            self.scalars_nb(),
+        ));
         let commitment = self.get_commitment(challenge, &response).unwrap();
         (commitment, response)
     }

--- a/src/trait.rs
+++ b/src/trait.rs
@@ -94,9 +94,9 @@ pub trait SigmaProtocol {
 /// Types implementing `CompactProtocol` must define:
 /// - `get_commitment`
 pub trait CompactProtocol: SigmaProtocol {
-    /// Returns the commitment for which ('commitment', 'challenge', 'response') is a valid transcript
+    /// Returns the commitment for which ('commitment', 'challenge', 'response') is a valid transcript.
     ///
-    /// This function allows to omit commitment in compact proofs of the type ('challenge', 'response')
+    /// This function allows to omit commitment in compact proofs of the type ('challenge', 'response').
     fn get_commitment(
         &self,
         challenge: &Self::Challenge,

--- a/src/trait.rs
+++ b/src/trait.rs
@@ -1,6 +1,6 @@
 //! Sigma Protocol Trait
 //!
-//! This module defines the `SigmaProtocol` trait, a generic interface for 3-message Sigma protocols.
+//! This module defines the [`SigmaProtocol`] trait, a generic interface for 3-message Sigma protocols.
 
 use crate::ProofError;
 use rand::{CryptoRng, Rng};
@@ -19,7 +19,7 @@ use rand::{CryptoRng, Rng};
 /// - `Challenge`: The verifier's challenge value.
 ///
 /// ## Minimal Implementation
-/// Types implementing `SigmaProtocol` must define:
+/// Types implementing [`SigmaProtocol`] must define:
 /// - `prover_commit`
 /// - `prover_response`
 /// - `verifier`
@@ -91,7 +91,7 @@ pub trait SigmaProtocol {
 /// This is what the get_commitment function is for.
 ///
 /// ## Minimal Implementation
-/// Types implementing `CompactProtocol` must define:
+/// Types implementing [`CompactProtocol`] must define:
 /// - `get_commitment`
 pub trait CompactProtocol: SigmaProtocol {
     /// Returns the commitment for which ('commitment', 'challenge', 'response') is a valid transcript.
@@ -134,7 +134,7 @@ pub trait CompactProtocol: SigmaProtocol {
 /// However, some protocols (like OR protocols that prove the truth of one-out-of-two statements) require them during for the real execution.
 ///
 /// ## Minimal Implementation
-/// Types implementing `SigmaProtocolSimulator` must define:
+/// Types implementing [`SigmaProtocolSimulator`] must define:
 /// - `simulate_proof`
 /// - `simulate_transcript`
 pub trait SigmaProtocolSimulator: SigmaProtocol {

--- a/tests/morphism_preimage.rs
+++ b/tests/morphism_preimage.rs
@@ -96,15 +96,14 @@ fn pedersen_commitment_dleq<G: Group + GroupEncoding>(
 ) -> (GroupMorphismPreimage<G>, Vec<G::Scalar>) {
     let mut morphismp: GroupMorphismPreimage<G> = GroupMorphismPreimage::new();
 
-    let mut generators = Vec::<G>::new();
-    generators.push(G::random(&mut *rng));
-    generators.push(G::random(&mut *rng));
-    generators.push(G::random(&mut *rng));
-    generators.push(G::random(&mut *rng));
+    let generators: Vec<G> = vec![
+        G::random(&mut *rng),
+        G::random(&mut *rng),
+        G::random(&mut *rng),
+        G::random(&mut *rng),
+    ];
 
-    let mut witness = Vec::<G::Scalar>::new();
-    witness.push(G::Scalar::random(&mut *rng));
-    witness.push(G::Scalar::random(&mut *rng));
+    let witness: Vec<G::Scalar> = vec![G::Scalar::random(&mut *rng), G::Scalar::random(&mut *rng)];
 
     let X = msm_pr::<G>(&witness, &[generators[0], generators[1]]);
     let Y = msm_pr::<G>(&witness, &[generators[2], generators[3]]);

--- a/tests/proof_builder.rs
+++ b/tests/proof_builder.rs
@@ -24,14 +24,14 @@ fn discrete_logarithm() {
     let G = G::generator();
     proof_builder.set_elements(&[(var_G, G)]);
 
-    let witness= vec![Scalar::random(rng)];
-    
+    let witness = vec![Scalar::random(rng)];
+
     let X = G * witness[0];
     proof_builder.set_elements(&[(var_X, X)]);
 
     // Prove and verify a proof
     let proof_bytes = proof_builder.prove(&witness, &mut rng).unwrap();
-     let result = proof_builder.verify(&proof_bytes).is_ok();
+    let result = proof_builder.verify(&proof_bytes).is_ok();
 
     // Prove and verify a compact proof
     let compact_proof_bytes = proof_builder.prove_compact(&witness, &mut rng).unwrap();

--- a/tests/proof_builder.rs
+++ b/tests/proof_builder.rs
@@ -24,25 +24,18 @@ fn discrete_logarithm() {
     let G = G::generator();
     proof_builder.set_elements(&[(var_G, G)]);
 
-    let mut witness = Vec::new();
-    witness.push(Scalar::random(rng));
-
+    let witness= vec![Scalar::random(rng)];
+    
     let X = G * witness[0];
     proof_builder.set_elements(&[(var_X, X)]);
 
     // Prove and verify a proof
     let proof_bytes = proof_builder.prove(&witness, &mut rng).unwrap();
-    let result = match proof_builder.verify(&proof_bytes) {
-        Ok(_) => true,
-        _ => false,
-    };
+     let result = proof_builder.verify(&proof_bytes).is_ok();
 
     // Prove and verify a compact proof
     let compact_proof_bytes = proof_builder.prove_compact(&witness, &mut rng).unwrap();
-    let compact_result = match proof_builder.verify_compact(&compact_proof_bytes) {
-        Ok(_) => true,
-        _ => false,
-    };
+    let compact_result = proof_builder.verify_compact(&compact_proof_bytes).is_ok();
 
     assert!(result);
     assert!(compact_result);

--- a/tests/spec/bls12_381.rs
+++ b/tests/spec/bls12_381.rs
@@ -35,7 +35,7 @@ impl SRandom for G1Projective {
         assert!(l <= h);
         let range = h - l + BigUint::one();
         let bits = range.bits();
-        let bytes_needed = ((bits + 7) / 8) as usize;
+        let bytes_needed = bits.div_ceil(8) as usize;
 
         loop {
             let mut buf = vec![0u8; bytes_needed];

--- a/tests/spec/sage_test_vectors.rs
+++ b/tests/spec/sage_test_vectors.rs
@@ -151,7 +151,7 @@ fn pedersen_commitment_dleq<G: Group + GroupEncoding + SRandom>(
 ) -> (Preimage<G>, Vec<G::Scalar>) {
     let mut morphismp: Preimage<G> = Preimage::new();
 
-        let generators: Vec<G> = vec![
+    let generators: Vec<G> = vec![
         G::prandom(rng),
         G::prandom(rng),
         G::prandom(rng),
@@ -159,7 +159,6 @@ fn pedersen_commitment_dleq<G: Group + GroupEncoding + SRandom>(
     ];
 
     let witness: Vec<G::Scalar> = vec![G::srandom(rng), G::srandom(rng)];
-
 
     let X = msm_pr::<G>(&witness, &[generators[0], generators[1]]);
     let Y = msm_pr::<G>(&witness, &[generators[2], generators[3]]);

--- a/tests/spec/sage_test_vectors.rs
+++ b/tests/spec/sage_test_vectors.rs
@@ -21,6 +21,7 @@ type Codec = ByteSchnorrCodec<Gp, KeccakDuplexSponge>;
 type SigmaP = SchnorrProtocolCustom<Gp>;
 type NISigmaP = NISigmaProtocol<SigmaP, Codec, Gp>;
 
+#[allow(clippy::type_complexity)]
 #[allow(non_snake_case)]
 #[test]
 fn sage_test_vectors() {
@@ -150,15 +151,15 @@ fn pedersen_commitment_dleq<G: Group + GroupEncoding + SRandom>(
 ) -> (Preimage<G>, Vec<G::Scalar>) {
     let mut morphismp: Preimage<G> = Preimage::new();
 
-    let mut generators = Vec::<G>::new();
-    generators.push(G::prandom(rng));
-    generators.push(G::prandom(rng));
-    generators.push(G::prandom(rng));
-    generators.push(G::prandom(rng));
+        let generators: Vec<G> = vec![
+        G::prandom(rng),
+        G::prandom(rng),
+        G::prandom(rng),
+        G::prandom(rng),
+    ];
 
-    let mut witness = Vec::<G::Scalar>::new();
-    witness.push(G::srandom(rng));
-    witness.push(G::srandom(rng));
+    let witness: Vec<G::Scalar> = vec![G::srandom(rng), G::srandom(rng)];
+
 
     let X = msm_pr::<G>(&witness, &[generators[0], generators[1]]);
     let Y = msm_pr::<G>(&witness, &[generators[2], generators[3]]);

--- a/tests/spec/test_drng.rs
+++ b/tests/spec/test_drng.rs
@@ -21,7 +21,7 @@ impl TestDRNG {
         assert!(l <= h);
         let range = h - l + 1;
         let bits = 64 - range.leading_zeros();
-        let bytes_needed = ((bits + 7) / 8) as usize;
+        let bytes_needed = bits.div_ceil(8) as usize;
 
         loop {
             let mut buf = vec![0u8; bytes_needed];
@@ -40,7 +40,7 @@ impl TestDRNG {
         assert!(l <= h);
         let range = h - l + BigUint::one();
         let bits = range.bits();
-        let bytes_needed = ((bits + 7) / 8) as usize;
+        let bytes_needed = bits.div_ceil(8) as usize;
 
         loop {
             let mut buf = vec![0u8; bytes_needed];


### PR DESCRIPTION
This PR enhances the documentation by adding proper Markdown hyperlinks to struct names.
Additionally, I ran cargo fmt to ensure consistent code formatting throughout the codebase.