### PR TITLE
feat(fiat-shamir): absorb morphism structure into transcript codec

### DIFF
--- a/src/codec/shake_codec.rs
+++ b/src/codec/shake_codec.rs
@@ -27,7 +27,7 @@ use crate::codec::r#trait::Codec;
 ///
 /// The codec is initialized with a domain separator and absorbs serialized
 /// group elements. It outputs challenges compatible with the group’s scalar field.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ShakeCodec<G: Group> {
     /// Internal SHAKE128 hasher state.
     hasher: Shake128,

--- a/src/schnorr_protocol.rs
+++ b/src/schnorr_protocol.rs
@@ -5,7 +5,7 @@
 //! through a group morphism abstraction (see Maurer09).
 
 use crate::errors::Error;
-use crate::group_morphism::GroupMorphismPreimage;
+use crate::group_morphism::{GroupMorphismPreimage, HasGroupMorphism};
 use crate::{
     group_serialization::*,
     traits::{CompactProtocol, SigmaProtocol, SigmaProtocolSimulator},
@@ -22,7 +22,7 @@ use rand::{CryptoRng, RngCore};
 ///
 /// # Type Parameters
 /// - `G`: A cryptographic group implementing [`Group`] and [`GroupEncoding`].
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct SchnorrProtocol<G: Group + GroupEncoding>(GroupMorphismPreimage<G>);
 
 impl<G: Group + GroupEncoding> SchnorrProtocol<G> {
@@ -394,5 +394,11 @@ where
         let challenge = G::Scalar::random(&mut *rng);
         let (commitment, response) = self.simulate_proof(&challenge, rng);
         (commitment, challenge, response)
+    }
+}
+
+impl<G: Group + GroupEncoding> HasGroupMorphism<G> for SchnorrProtocol<G> {
+    fn group_morphism(&self) -> &GroupMorphismPreimage<G> {
+        &self.0
     }
 }

--- a/tests/morphism_preimage.rs
+++ b/tests/morphism_preimage.rs
@@ -3,6 +3,7 @@ use group::{Group, ff::Field};
 use rand::rngs::OsRng;
 
 use sigma_rs::fiat_shamir::NISigmaProtocol;
+use sigma_rs::group_morphism::HasGroupMorphism;
 use sigma_rs::test_utils::{
     bbs_blind_commitment_computation, discrete_logarithm, dleq, pedersen_commitment,
     pedersen_commitment_dleq,
@@ -96,6 +97,42 @@ fn noninteractive_discrete_logarithm() {
         "Fiat-Shamir Schnorr proof verification failed"
     );
 }
+
+/// This part tests the implementation of the SigmaProtocol trait for the
+/// SchnorrProtocol structure as well as the Fiat-Shamir NISigmaProtocol transform,
+/// with additional morphism structure absorption into the transcript.
+#[test]
+fn noninteractive_discrete_logarithm_with_morphism_transcript() {
+    let mut rng = OsRng;
+    let (morphismp, witness) = discrete_logarithm(Scalar::random(&mut rng));
+
+    // The SigmaProtocol induced by morphismp
+    let protocol = SchnorrProtocol::from(morphismp);
+
+    // Fiat-Shamir wrapper
+    let domain_sep = b"test-fiat-shamir-schnorr";
+    let mut nizk = NISigmaProtocol::<SchnorrProtocol<G>, ShakeCodec<G>, G>::new(domain_sep, protocol);
+
+    // Morphism absorption
+    nizk.sigmap.absorb_morphism_structure(&mut nizk.hash_state).unwrap();
+
+    // Generate and verify proofs
+    let proof_batchable_bytes = nizk.prove_batchable(&witness, &mut rng).unwrap();
+    let proof_compact_bytes = nizk.prove_compact(&witness, &mut rng).unwrap();
+
+    let verified_batchable = nizk.verify_batchable(&proof_batchable_bytes).is_ok();
+    let verified_compact = nizk.verify_compact(&proof_compact_bytes).is_ok();
+
+    assert!(
+        verified_batchable,
+        "Fiat-Shamir Schnorr proof with morphism absorption failed (batchable)"
+    );
+    assert!(
+        verified_compact,
+        "Fiat-Shamir Schnorr proof with morphism absorption failed (compact)"
+    );
+}
+
 
 #[test]
 fn noninteractive_dleq() {


### PR DESCRIPTION
This commit introduces a new `HasGroupMorphism` trait to allow SigmaProtocol implementations to expose their underlying group morphism structure.

A helper method `absorb_morphism_structure` was added to the trait, enabling a standard way to serialize and absorb the morphism constraints into a transcript codec during Fiat-Shamir initialization.

Changes include:
- Definition of `HasGroupMorphism` with `group_morphism()` accessor
- Default implementation of `absorb_morphism_structure` using term indices
- Conditional `impl` block in `NISigmaProtocol` for protocols implementing `HasGroupMorphism`, enabling morphism-to-transcript absorption
- Unit test in `tests/morphism_preimage.rs` to verify correctness

This prepares the ground for composable Fiat-Shamir transformations that include problem structure in the transcript, improving soundness under rewinding.

#14 