### PR TITLE
feat(protocol): support HasGroupMorphism for composite variants in Protocol enum

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -27,6 +27,6 @@ pub enum Error {
     /// Uninitialized group element variable.
     #[error("Uninitialized group element variable {var:?}")]
     UnassignedGroupVar { var: GroupVar },
-    #[error("Morphism absorbtion failed")]
-    MorphismAbsorbtionFailure,
+    #[error("Morphism absorption failed")]
+    MorphismAbsorptionFailure,
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -27,4 +27,6 @@ pub enum Error {
     /// Uninitialized group element variable.
     #[error("Uninitialized group element variable {var:?}")]
     UnassignedGroupVar { var: GroupVar },
+    #[error("Morphism absorbtion failed")]
+    MorphismAbsorbtionFailure,
 }

--- a/src/group_morphism.rs
+++ b/src/group_morphism.rs
@@ -464,12 +464,12 @@ where
 /// Trait for accessing the underlying group morphism in a Sigma protocol.
 pub trait HasGroupMorphism {
     type Group: Group + GroupEncoding;
-    fn group_morphism(&self) -> &GroupMorphismPreimage<Self::Group>;
+    fn group_morphism(&self) -> Result<&GroupMorphismPreimage<Self::Group>, Error>;
 
     /// Absorbs the morphism structure into a codec.
     /// Only compatible with 64-bit platforms
     fn absorb_morphism_structure<C: Codec>(&self, codec: &mut C) -> Result<(), Error> {
-        let morphism = self.group_morphism();
+        let morphism = self.group_morphism()?;
         for lc in &morphism.morphism.constraints {
             for term in lc.terms() {
                 let mut buf = [0u8; 16];

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -630,7 +630,7 @@ impl<G: Group + GroupEncoding> HasGroupMorphism for Protocol<G> {
     fn group_morphism(&self) -> Result<&GroupMorphismPreimage<G>, Error> {
         match self {
             Protocol::Simple(p) => p.group_morphism(),
-            Protocol::And(_) | Protocol::Or(_) => Err(Error::MorphismAbsorbtionFailure),
+            Protocol::And(_) | Protocol::Or(_) => Err(Error::MorphismAbsorptionFailure),
         }
     }
 

--- a/src/schnorr_protocol.rs
+++ b/src/schnorr_protocol.rs
@@ -432,7 +432,7 @@ where
 
 impl<G: Group + GroupEncoding> HasGroupMorphism for SchnorrProtocol<G> {
     type Group = G;
-    fn group_morphism(&self) -> &GroupMorphismPreimage<G> {
-        &self.0
+    fn group_morphism(&self) -> Result<&GroupMorphismPreimage<G>, Error> {
+        Ok(&self.0)
     }
 }

--- a/tests/composition_protocol.rs
+++ b/tests/composition_protocol.rs
@@ -102,7 +102,7 @@ fn composition_proof_correct() {
 
 #[allow(non_snake_case)]
 #[test]
-fn composition_proof_correct_with_morphism_absorbtion() {
+fn composition_proof_correct_with_morphism_absorption() {
     // Composition and verification of proof for the following protocol :
     //
     // protocol = And(
@@ -174,7 +174,7 @@ fn composition_proof_correct_with_morphism_absorbtion() {
     let mut nizk =
         NISigmaProtocol::<Protocol<RistrettoPoint>, ShakeCodec<G>>::new(domain_sep, protocol);
 
-    // Morphism absorbtion
+    // Morphism absorption
     nizk.sigmap
         .absorb_morphism_structure(&mut nizk.hash_state)
         .unwrap();

--- a/tests/composition_protocol.rs
+++ b/tests/composition_protocol.rs
@@ -4,6 +4,7 @@ use rand::rngs::OsRng;
 
 use sigma_rs::codec::ShakeCodec;
 use sigma_rs::fiat_shamir::NISigmaProtocol;
+use sigma_rs::group_morphism::HasGroupMorphism;
 use sigma_rs::protocol::{Protocol, ProtocolWitness};
 use sigma_rs::schnorr_protocol::SchnorrProtocol;
 use sigma_rs::test_utils::{
@@ -86,6 +87,97 @@ fn composition_proof_correct() {
 
     let nizk =
         NISigmaProtocol::<Protocol<RistrettoPoint>, ShakeCodec<G>>::new(domain_sep, protocol);
+
+    // Batchable and compact proofs
+    let proof_batchable_bytes = nizk.prove_batchable(&witness, &mut rng).unwrap();
+    let proof_compact_bytes = nizk.prove_compact(&witness, &mut rng).unwrap();
+    // Verify proofs
+    let verified_batchable = nizk.verify_batchable(&proof_batchable_bytes).is_ok();
+    let verified_compact = nizk.verify_compact(&proof_compact_bytes).is_ok();
+    assert!(
+        verified_batchable & verified_compact,
+        "Fiat-Shamir Schnorr proof verification failed"
+    );
+}
+
+#[allow(non_snake_case)]
+#[test]
+fn composition_proof_correct_with_morphism_absorbtion() {
+    // Composition and verification of proof for the following protocol :
+    //
+    // protocol = And(
+    //     Or( dleq, pedersen_commitment ),
+    //     Simple( discrete_logarithm ),
+    //     And( pedersen_commitment_dleq, bbs_blind_commitment_computation )
+    // )
+    let mut rng = OsRng;
+    let domain_sep = b"hello world";
+
+    // definitions of the underlying protocols
+    let (morph1, witness1) = dleq(<G as Group>::Scalar::random(&mut rng), G::random(&mut rng));
+    let (morph2, _) = pedersen_commitment(
+        G::random(&mut rng),
+        <G as Group>::Scalar::random(&mut rng),
+        <G as Group>::Scalar::random(&mut rng),
+    );
+    let (morph3, witness3) = discrete_logarithm(<G as Group>::Scalar::random(&mut rng));
+    let (morph4, witness4) = pedersen_commitment_dleq(
+        (0..4)
+            .map(|_| G::random(&mut rng))
+            .collect::<Vec<_>>()
+            .try_into()
+            .unwrap(),
+        (0..2)
+            .map(|_| <G as Group>::Scalar::random(&mut rng))
+            .collect::<Vec<_>>()
+            .try_into()
+            .unwrap(),
+    );
+    let (morph5, witness5) = bbs_blind_commitment_computation(
+        (0..4)
+            .map(|_| G::random(&mut rng))
+            .collect::<Vec<_>>()
+            .try_into()
+            .unwrap(),
+        (0..3)
+            .map(|_| <G as Group>::Scalar::random(&mut rng))
+            .collect::<Vec<_>>()
+            .try_into()
+            .unwrap(),
+        <G as Group>::Scalar::random(&mut rng),
+    );
+
+    // second layer protocol definitions
+    let or_protocol1 = Protocol::Or(vec![
+        Protocol::Simple(SchnorrProtocol::from(morph1)),
+        Protocol::Simple(SchnorrProtocol::from(morph2)),
+    ]);
+    let or_witness1 =
+        sigma_rs::protocol::ProtocolWitness::Or(0, vec![ProtocolWitness::Simple(witness1)]);
+
+    let simple_protocol1 = Protocol::Simple(SchnorrProtocol::from(morph3));
+    let simple_witness1 = ProtocolWitness::Simple(witness3);
+
+    let and_protocol1 = Protocol::And(vec![
+        Protocol::Simple(SchnorrProtocol::from(morph4)),
+        Protocol::Simple(SchnorrProtocol::from(morph5)),
+    ]);
+    let and_witness1 = ProtocolWitness::And(vec![
+        ProtocolWitness::Simple(witness4),
+        ProtocolWitness::Simple(witness5),
+    ]);
+
+    // definition of the final protocol
+    let protocol = Protocol::And(vec![or_protocol1, simple_protocol1, and_protocol1]);
+    let witness = ProtocolWitness::And(vec![or_witness1, simple_witness1, and_witness1]);
+
+    let mut nizk =
+        NISigmaProtocol::<Protocol<RistrettoPoint>, ShakeCodec<G>>::new(domain_sep, protocol);
+
+    // Morphism absorbtion
+    nizk.sigmap
+        .absorb_morphism_structure(&mut nizk.hash_state)
+        .unwrap();
 
     // Batchable and compact proofs
     let proof_batchable_bytes = nizk.prove_batchable(&witness, &mut rng).unwrap();


### PR DESCRIPTION
Recursively absorbs morphism structure from And/Or protocols, enabling Fiat–Shamir support