### PR TITLE
fix(ci): use nightly toolchain for cargo doc in GitHub Pages workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           toolchain: nightly
       - name: cargo +nightly doc
-        run: RUSTDOCFLAGS="-Z unstable-options --enable-index-page" cargo doc --all-features
+        run: RUSTDOCFLAGS="-Z unstable-options --enable-index-page" cargo +nightly doc --all-features
       - name: page configuration
         uses: actions/configure-pages@v3
       - name: Upload artifact


### PR DESCRIPTION
This PR updates the docs.yml workflow to use the nightly Rust toolchain for cargo doc.

It explicitly runs:
cargo +nightly doc --all-features
This is required to use nightly-only flags:

-Z unstable-options

--enable-index-page

These flags previously caused the cargo doc step to fail due to the rust-toolchain file pinning stable Rust (1.87.0).

The nightly toolchain is now explicitly installed and invoked only for documentation generation.