### PR TITLE
feat: absorb morphism into Fiat-Shamir transcript for SchnorrProtocol

### DIFF
--- a/src/composition.rs
+++ b/src/composition.rs
@@ -16,8 +16,8 @@ use crate::traits::CompactProtocol;
 use crate::{
     errors::Error,
     fiat_shamir::FiatShamir,
-    linear_relation::LinearRelation,
     group_serialization::{deserialize_scalar, serialize_scalar},
+    linear_relation::LinearRelation,
     schnorr_protocol::SchnorrProtocol,
     traits::{SigmaProtocol, SigmaProtocolSimulator},
 };

--- a/src/composition.rs
+++ b/src/composition.rs
@@ -15,7 +15,7 @@ use crate::codec::Codec;
 use crate::traits::CompactProtocol;
 use crate::{
     errors::Error,
-    fiat_shamir::{FiatShamir, HasGroupMorphism},
+    fiat_shamir::FiatShamir,
     linear_relation::LinearRelation,
     group_serialization::{deserialize_scalar, serialize_scalar},
     schnorr_protocol::SchnorrProtocol,
@@ -637,17 +637,19 @@ where
     G: Group + GroupEncoding,
     C: Codec<Challenge = ProtocolChallenge<G>>,
 {
-    fn push_commitment(&self, codec: &mut C, commitment: &Self::Commitment) {
+    fn absorb_statement_and_commitment(&self, codec: &mut C, commitment: &Self::Commitment) {
         match (self, commitment) {
-            (Protocol::Simple(p), ProtocolCommitment::Simple(c)) => p.push_commitment(codec, c),
+            (Protocol::Simple(p), ProtocolCommitment::Simple(c)) => {
+                p.absorb_statement_and_commitment(codec, c)
+            }
             (Protocol::And(ps), ProtocolCommitment::And(cs)) => {
                 for (i, p) in ps.iter().enumerate() {
-                    p.push_commitment(codec, &cs[i]);
+                    p.absorb_statement_and_commitment(codec, &cs[i]);
                 }
             }
             (Protocol::Or(ps), ProtocolCommitment::Or(cs)) => {
                 for (i, p) in ps.iter().enumerate() {
-                    p.push_commitment(codec, &cs[i]);
+                    p.absorb_statement_and_commitment(codec, &cs[i]);
                 }
             }
             _ => panic!(),
@@ -656,19 +658,5 @@ where
 
     fn get_challenge(&self, codec: &mut C) -> Result<Self::Challenge, Error> {
         Ok(codec.verifier_challenge())
-    }
-}
-
-impl<G: Group + GroupEncoding> HasGroupMorphism for Protocol<G> {
-    fn absorb_morphism_structure<C: Codec>(&self, codec: &mut C) -> Result<(), Error> {
-        match self {
-            Protocol::Simple(p) => p.absorb_morphism_structure(codec),
-            Protocol::And(ps) | Protocol::Or(ps) => {
-                for p in ps {
-                    p.absorb_morphism_structure(codec)?
-                }
-                Ok(())
-            }
-        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,8 @@
 pub mod composition;
 pub mod errors;
 pub mod fiat_shamir;
-pub mod linear_relation;
 pub mod group_serialization;
+pub mod linear_relation;
 pub mod schnorr_protocol;
 pub mod traits;
 
@@ -24,6 +24,5 @@ pub mod codec;
 
 #[cfg(test)]
 pub mod tests;
-
 
 pub use linear_relation::LinearRelation;

--- a/src/linear_relation.rs
+++ b/src/linear_relation.rs
@@ -484,12 +484,7 @@ where
         out.write_all(&[ne as u8]).unwrap();
 
         // 2. Encode each equation with its LHS and terms
-        for (constraint, output_var) in self
-            .morphism
-            .constraints
-            .iter()
-            .zip(self.image.iter())
-        {
+        for (constraint, output_var) in self.morphism.constraints.iter().zip(self.image.iter()) {
             // a. Output point index (LHS)
             out.write_all(&[output_var.index() as u8]).unwrap();
 

--- a/src/linear_relation.rs
+++ b/src/linear_relation.rs
@@ -161,6 +161,13 @@ impl<G: Group> GroupMap<G> {
             .enumerate()
             .filter_map(|(i, x)| x.map(|x| (GroupVar(i), x)))
     }
+
+    pub fn iter(&self) -> impl Iterator<Item = (GroupVar, &G)> {
+        self.0
+            .iter()
+            .enumerate()
+            .filter_map(|(i, opt)| opt.as_ref().map(|g| (GroupVar(i), g)))
+    }
 }
 
 impl<G> Default for GroupMap<G> {

--- a/src/schnorr_protocol.rs
+++ b/src/schnorr_protocol.rs
@@ -418,50 +418,14 @@ where
     /// # Parameters
     /// - `codec`: the Codec that absorbs commitments
     /// - `commitment`: a commitment of SchnorrProtocol
-    ///
-    /// # Source
-    /// The structure is Taken from the Signal implementation
-    /// https://github.com/signalapp/libsignal/blob/427722720357ef8c909a2b276a68205a160c5ea6/rust/poksho/src/statement.rs#L12-L91
     fn absorb_statement_and_commitment(&self, codec: &mut C, commitment: &Self::Commitment) {
-        let morphism = &self.0.morphism;
+        let mut data = self.0.label();
 
-        // Step 1: Absorb protocol label (L)
-        codec.prover_message(b"label:SIGMA_RS_SCHNORR");
-
-        // Step 2: Absorb description (D) of the homomorphism
-        let ne = morphism.constraints.len();
-        codec.prover_message(b"desc:eq_count:");
-        codec.prover_message(&[ne as u8]);
-
-        for (i, constraint) in morphism.constraints.iter().enumerate() {
-            let lhs = i as u8;
-            let nt = constraint.terms().len() as u8;
-
-            codec.prover_message(format!("desc:eq:{}:lhs:", i).as_bytes());
-            codec.prover_message(&[lhs]);
-
-            codec.prover_message(format!("desc:eq:{}:nt:", i).as_bytes());
-            codec.prover_message(&[nt]);
-
-            for (j, term) in constraint.terms().iter().enumerate() {
-                let scalar = term.scalar().index() as u8;
-                let point = term.elem().index() as u8;
-                codec.prover_message(format!("desc:eq:{}:term:{}:", i, j).as_bytes());
-                codec.prover_message(&[scalar, point]);
-            }
+        for commit in commitment {
+            data.extend_from_slice(commit.to_bytes().as_ref());
         }
 
-        // Step 3: Absorb point values for statement (A)
-        for (i, point) in morphism.group_elements.iter() {
-            codec.prover_message(format!("point:{}:", i.index()).as_bytes());
-            codec.prover_message(point.to_bytes().as_ref());
-        }
-
-        // Step 4: Absorb commitment (R)
-        for (i, commit) in commitment.iter().enumerate() {
-            codec.prover_message(format!("commitment:{}:", i).as_bytes());
-            codec.prover_message(commit.to_bytes().as_ref());
-        }
+        codec.prover_message(&data);
     }
 
     /// Generates a challenge from the codec that absorbed the commitments

--- a/src/tests/composition.rs
+++ b/src/tests/composition.rs
@@ -8,7 +8,7 @@ use super::test_utils::{
 };
 use crate::codec::ShakeCodec;
 use crate::composition::{Protocol, ProtocolWitness};
-use crate::fiat_shamir::{HasGroupMorphism, NISigmaProtocol};
+use crate::fiat_shamir::NISigmaProtocol;
 use crate::schnorr_protocol::SchnorrProtocol;
 
 type G = RistrettoPoint;
@@ -83,12 +83,8 @@ fn composition_proof_correct() {
     let protocol = Protocol::And(vec![or_protocol1, simple_protocol1, and_protocol1]);
     let witness = ProtocolWitness::And(vec![or_witness1, simple_witness1, and_witness1]);
 
-    let mut nizk =
+    let nizk =
         NISigmaProtocol::<Protocol<RistrettoPoint>, ShakeCodec<G>>::new(domain_sep, protocol);
-
-    nizk.sigmap
-        .absorb_morphism_structure(&mut nizk.hash_state)
-        .unwrap();
 
     // Batchable and compact proofs
     let proof_batchable_bytes = nizk.prove_batchable(&witness, &mut rng).unwrap();

--- a/src/tests/composition_protocol.rs
+++ b/src/tests/composition_protocol.rs
@@ -8,7 +8,7 @@ use super::test_utils::{
 };
 use crate::codec::ShakeCodec;
 use crate::composition::{Protocol, ProtocolWitness};
-use crate::fiat_shamir::{HasGroupMorphism, NISigmaProtocol};
+use crate::fiat_shamir::NISigmaProtocol;
 use crate::schnorr_protocol::SchnorrProtocol;
 
 type G = RistrettoPoint;
@@ -83,12 +83,8 @@ fn composition_proof_correct() {
     let protocol = Protocol::And(vec![or_protocol1, simple_protocol1, and_protocol1]);
     let witness = ProtocolWitness::And(vec![or_witness1, simple_witness1, and_witness1]);
 
-    let mut nizk =
+    let nizk =
         NISigmaProtocol::<Protocol<RistrettoPoint>, ShakeCodec<G>>::new(domain_sep, protocol);
-
-    nizk.sigmap
-        .absorb_morphism_structure(&mut nizk.hash_state)
-        .unwrap();
 
     // Batchable and compact proofs
     let proof_batchable_bytes = nizk.prove_batchable(&witness, &mut rng).unwrap();

--- a/src/tests/relations.rs
+++ b/src/tests/relations.rs
@@ -2,7 +2,7 @@ use bls12_381::{G1Projective as G, Scalar};
 use group::{Group, ff::Field};
 use rand::rngs::OsRng;
 
-use crate::fiat_shamir::{HasGroupMorphism, NISigmaProtocol};
+use crate::fiat_shamir::NISigmaProtocol;
 use crate::tests::test_utils::{
     bbs_blind_commitment_computation, discrete_logarithm, dleq, pedersen_commitment,
     pedersen_commitment_dleq,
@@ -94,43 +94,6 @@ fn noninteractive_discrete_logarithm() {
     assert!(
         verified_compact,
         "Fiat-Shamir Schnorr proof verification failed"
-    );
-}
-
-/// This part tests the implementation of the SigmaProtocol trait for the
-/// SchnorrProtocol structure as well as the Fiat-Shamir NISigmaProtocol transform,
-/// with additional morphism structure absorption into the transcript.
-#[test]
-fn noninteractive_discrete_logarithm_with_morphism_transcript() {
-    let mut rng = OsRng;
-    let (morphismp, witness) = discrete_logarithm(Scalar::random(&mut rng));
-
-    // The SigmaProtocol induced by morphismp
-    let protocol = SchnorrProtocol::from(morphismp);
-
-    // Fiat-Shamir wrapper
-    let domain_sep = b"test-fiat-shamir-schnorr";
-    let mut nizk = NISigmaProtocol::<SchnorrProtocol<G>, ShakeCodec<G>>::new(domain_sep, protocol);
-
-    // Morphism absorption
-    nizk.sigmap
-        .absorb_morphism_structure(&mut nizk.hash_state)
-        .unwrap();
-
-    // Generate and verify proofs
-    let proof_batchable_bytes = nizk.prove_batchable(&witness, &mut rng).unwrap();
-    let proof_compact_bytes = nizk.prove_compact(&witness, &mut rng).unwrap();
-
-    let verified_batchable = nizk.verify_batchable(&proof_batchable_bytes).is_ok();
-    let verified_compact = nizk.verify_compact(&proof_compact_bytes).is_ok();
-
-    assert!(
-        verified_batchable,
-        "Fiat-Shamir Schnorr proof with morphism absorption failed (batchable)"
-    );
-    assert!(
-        verified_compact,
-        "Fiat-Shamir Schnorr proof with morphism absorption failed (compact)"
     );
 }
 

--- a/src/tests/spec/custom_schnorr_protocol.rs
+++ b/src/tests/spec/custom_schnorr_protocol.rs
@@ -5,8 +5,8 @@ use rand::{CryptoRng, Rng};
 use crate::codec::Codec;
 use crate::errors::Error;
 use crate::fiat_shamir::FiatShamir;
-use crate::linear_relation::LinearRelation;
 use crate::group_serialization::*;
+use crate::linear_relation::LinearRelation;
 use crate::tests::spec::random::SRandom;
 use crate::traits::SigmaProtocol;
 

--- a/src/tests/spec/custom_schnorr_protocol.rs
+++ b/src/tests/spec/custom_schnorr_protocol.rs
@@ -156,7 +156,7 @@ where
     C: Codec<Challenge = <G as Group>::Scalar>,
     G: SRandom + GroupEncoding,
 {
-    fn push_commitment(&self, codec: &mut C, commitment: &Self::Commitment) {
+    fn absorb_statement_and_commitment(&self, codec: &mut C, commitment: &Self::Commitment) {
         let mut data = Vec::new();
         for commit in commitment {
             data.extend_from_slice(commit.to_bytes().as_ref());

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -5,6 +5,7 @@
 use crate::errors::Error;
 use rand::{CryptoRng, Rng};
 
+type BatchableProofResult<C, R> = Result<((C, R), usize), Error>;
 /// A trait defining the behavior of a generic Sigma protocol.
 ///
 /// A Sigma protocol is a 3-message proof protocol where a prover can convince
@@ -74,7 +75,7 @@ pub trait SigmaProtocol {
     fn deserialize_batchable(
         &self,
         _data: &[u8],
-    ) -> Result<((Self::Commitment, Self::Response), usize), Error>;
+    ) -> BatchableProofResult<Self::Commitment, Self::Response>;
 }
 
 /// A feature defining the behavior of a protocol for which it is possible to compact the proofs by omitting the commitments.


### PR DESCRIPTION
- Implement `absorb_statement_and_commitment` to include morphism structure in every nizk proof/verification
- Remove `HasGroupMorphism` trait and implementations
- Verify correctness of end-to-end tests for composed protocols and morphisms

Close issue #14 