### PR TITLE
feat(sponge): allow arbitrary IV size in KeccakDuplexSponge constructor

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -55,7 +55,8 @@ where
     G: Group + GroupEncoding,
     H: DuplexSpongeInterface,
 {
-    pub fn from_duplex_sponge(hasher: H) -> Self {
+    pub fn from_iv(iv: &[u8]) -> Self {
+        let hasher = H::new(iv);
         Self {
             hasher,
             _marker: Default::default(),
@@ -71,7 +72,12 @@ where
     type Challenge = <G as Group>::Scalar;
 
     fn new(domain_sep: &[u8]) -> Self {
-        let hasher = H::new(domain_sep);
+        let iv = {
+            let mut tmp = H::new(&[0u8; 32]);
+            tmp.absorb(domain_sep);
+            tmp.squeeze(32)
+        };
+        let hasher = H::new(&iv);
         Self {
             hasher,
             _marker: Default::default(),

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -50,6 +50,19 @@ where
     _marker: core::marker::PhantomData<G>,
 }
 
+impl<G, H> ByteSchnorrCodec<G, H>
+where
+    G: Group + GroupEncoding,
+    H: DuplexSpongeInterface,
+{
+    pub fn from_duplex_sponge(hasher: H) -> Self {
+        Self {
+            hasher,
+            _marker: Default::default(),
+        }
+    }
+}
+
 impl<G, H> Codec for ByteSchnorrCodec<G, H>
 where
     G: Group + GroupEncoding,

--- a/src/duplex_sponge/keccak.rs
+++ b/src/duplex_sponge/keccak.rs
@@ -73,6 +73,15 @@ pub struct KeccakDuplexSponge {
 
 impl KeccakDuplexSponge {
     pub fn new(iv: &[u8]) -> Self {
+        let hashed_iv = {
+            let mut tmp = KeccakDuplexSponge::from_iv(&[0u8; 32]);
+            tmp.absorb(iv);
+            tmp.squeeze(32)
+        };
+        KeccakDuplexSponge::from_iv(&hashed_iv)
+    }
+
+    pub fn from_iv(iv: &[u8]) -> Self {
         assert_eq!(iv.len(), 32);
 
         let state = KeccakPermutationState::new(iv.try_into().unwrap());

--- a/src/duplex_sponge/keccak.rs
+++ b/src/duplex_sponge/keccak.rs
@@ -73,15 +73,6 @@ pub struct KeccakDuplexSponge {
 
 impl KeccakDuplexSponge {
     pub fn new(iv: &[u8]) -> Self {
-        let hashed_iv = {
-            let mut tmp = KeccakDuplexSponge::from_iv(&[0u8; 32]);
-            tmp.absorb(iv);
-            tmp.squeeze(32)
-        };
-        KeccakDuplexSponge::from_iv(&hashed_iv)
-    }
-
-    pub fn from_iv(iv: &[u8]) -> Self {
         assert_eq!(iv.len(), 32);
 
         let state = KeccakPermutationState::new(iv.try_into().unwrap());

--- a/src/tests/spec/test_vectors.rs
+++ b/src/tests/spec/test_vectors.rs
@@ -28,7 +28,11 @@ macro_rules! generate_ni_function {
 
             let protocol = SchnorrProtocolCustom(morphismp);
             let domain_sep: Vec<u8> = context.to_vec();
-            let nizk = NISigmaP::new(&domain_sep, protocol);
+            let codec = Codec::from_duplex_sponge(KeccakDuplexSponge::from_iv(&domain_sep));
+            let nizk = NISigmaP {
+                hash_state: codec,
+                ip: protocol
+                };
 
             let proof_bytes = nizk.prove_batchable(&witness, &mut rng).unwrap();
             let verified = nizk.verify_batchable(&proof_bytes).is_ok();

--- a/src/tests/spec/test_vectors.rs
+++ b/src/tests/spec/test_vectors.rs
@@ -28,7 +28,7 @@ macro_rules! generate_ni_function {
 
             let protocol = SchnorrProtocolCustom(morphismp);
             let domain_sep: Vec<u8> = context.to_vec();
-            let codec = Codec::from_duplex_sponge(KeccakDuplexSponge::from_iv(&domain_sep));
+            let codec = Codec::from_iv(&domain_sep);
             let nizk = NISigmaP {
                 hash_state: codec,
                 ip: protocol


### PR DESCRIPTION
- feat: modify new() method for KeccakDuplexSponge to accept initialization vectors of any size