### PR TITLE
[WIP] Implement scalar multiplication, negation, and subtraction for variables

### DIFF
--- a/src/linear_relation/mod.rs
+++ b/src/linear_relation/mod.rs
@@ -91,6 +91,8 @@ impl<T> Sum<T> {
     }
 }
 
+// NOTE: This is implemented directly for each of the key types to avoid collision with the blanket
+// Into impl provided by the standard library.
 macro_rules! impl_from_for_sum {
     ($($type:ty),+) => {
         $(
@@ -102,13 +104,13 @@ macro_rules! impl_from_for_sum {
 
         impl<T: Into<$type>> From<Vec<T>> for Sum<$type> {
             fn from(terms: Vec<T>) -> Self {
-                Self(terms.into_iter().map(|x| x.into()).collect())
+                Self::from_iter(terms)
             }
         }
 
         impl<T: Into<$type>, const N: usize> From<[T; N]> for Sum<$type> {
             fn from(terms: [T; N]) -> Self {
-                Self(terms.into_iter().map(|x| x.into()).collect())
+                Self::from_iter(terms)
             }
         }
 
@@ -126,13 +128,13 @@ macro_rules! impl_from_for_sum {
 
         impl<F, T: Into<Weighted<$type, F>>> From<Vec<T>> for Sum<Weighted<$type, F>> {
             fn from(terms: Vec<T>) -> Self {
-                Self(terms.into_iter().map(|x| x.into()).collect())
+                Self::from_iter(terms)
             }
         }
 
         impl<F, T: Into<Weighted<$type, F>>, const N: usize> From<[T; N]> for Sum<Weighted<$type, F>> {
             fn from(terms: [T; N]) -> Self {
-                Self(terms.into_iter().map(|x| x.into()).collect())
+                Self::from_iter(terms)
             }
         }
 

--- a/src/linear_relation/ops.rs
+++ b/src/linear_relation/ops.rs
@@ -1,56 +1,283 @@
-use core::ops::{Add, Mul};
+use core::ops::{Add, Mul, Neg, Sub};
+use ff::Field;
 
-use super::{GroupVar, LinearCombination, ScalarVar, Term};
+use super::{GroupVar, ScalarVar, Sum, Term, Weighted};
 
-impl Add<LinearCombination> for LinearCombination {
-    type Output = Self;
+mod add {
+    use super::*;
 
-    fn add(mut self, mut rhs: LinearCombination) -> Self {
-        self.0.append(&mut rhs.0);
-        self
+    macro_rules! impl_add_term {
+        ($($type:ty),+) => {
+            $(
+            impl Add<$type> for $type {
+                type Output = Sum<$type>;
+
+                fn add(self, rhs: $type) -> Self::Output {
+                    Sum(vec![self, rhs])
+                }
+            }
+            )+
+        };
     }
+
+    impl_add_term!(ScalarVar, GroupVar, Term);
+
+    impl<T> Add<T> for Sum<T> {
+        type Output = Sum<T>;
+
+        fn add(mut self, rhs: T) -> Self::Output {
+            self.0.push(rhs);
+            self
+        }
+    }
+
+    macro_rules! impl_add_sum_term {
+        ($($type:ty),+) => {
+            $(
+            impl Add<Sum<$type>> for $type {
+                type Output = Sum<$type>;
+
+                fn add(self, rhs: Sum<$type>) -> Self::Output {
+                    rhs + self
+                }
+            }
+            )+
+        };
+    }
+
+    impl_add_sum_term!(ScalarVar, GroupVar, Term);
+
+    impl<T> Add<Sum<T>> for Sum<T> {
+        type Output = Sum<T>;
+
+        fn add(mut self, rhs: Sum<T>) -> Self::Output {
+            self.0.extend(rhs.0);
+            self
+        }
+    }
+
+    impl<T, F> Add<Weighted<T, F>> for Weighted<T, F> {
+        type Output = Sum<Weighted<T, F>>;
+
+        fn add(self, rhs: Weighted<T, F>) -> Self::Output {
+            Sum(vec![self, rhs])
+        }
+    }
+
+    impl<T, F: Field> Add<T> for Weighted<T, F> {
+        type Output = Sum<Weighted<T, F>>;
+
+        fn add(self, rhs: T) -> Self::Output {
+            Sum(vec![self, rhs.into()])
+        }
+    }
+
+    macro_rules! impl_add_weighted_term {
+        ($($type:ty),+) => {
+            $(
+            impl<F: Field> Add<Weighted<$type, F>> for $type {
+                type Output = Sum<Weighted<$type, F>>;
+
+                fn add(self, rhs: Weighted<$type, F>) -> Self::Output {
+                    rhs + self
+                }
+            }
+            )+
+        };
+    }
+
+    impl_add_weighted_term!(ScalarVar, GroupVar, Term);
+
+    impl<T, F: Field> Add<T> for Sum<Weighted<T, F>> {
+        type Output = Sum<Weighted<T, F>>;
+
+        fn add(mut self, rhs: T) -> Self::Output {
+            self.0.push(rhs.into());
+            self
+        }
+    }
+
+    macro_rules! impl_add_weighted_sum_term {
+        ($($type:ty),+) => {
+            $(
+            impl<F: Field> Add<Sum<Weighted<$type, F>>> for $type {
+                type Output = Sum<Weighted<$type, F>>;
+
+                fn add(self, rhs: Sum<Weighted<$type, F>>) -> Self::Output {
+                    rhs + self
+                }
+            }
+            )+
+        };
+    }
+
+    impl_add_weighted_sum_term!(ScalarVar, GroupVar, Term);
 }
 
-impl Add<Term> for LinearCombination {
-    type Output = LinearCombination;
+mod mul {
+    use super::*;
 
-    fn add(mut self, rhs: Term) -> LinearCombination {
-        self.0.push(rhs);
-        self
+    impl Mul<ScalarVar> for GroupVar {
+        type Output = Term;
+
+        /// Multiply a [ScalarVar] by a [GroupVar] to form a new [Term].
+        fn mul(self, rhs: ScalarVar) -> Term {
+            Term {
+                elem: self,
+                scalar: rhs,
+            }
+        }
     }
-}
 
-impl Add<LinearCombination> for Term {
-    type Output = LinearCombination;
+    impl Mul<GroupVar> for ScalarVar {
+        type Output = Term;
 
-    fn add(self, rhs: LinearCombination) -> LinearCombination {
-        rhs + self
+        /// Multiply a [ScalarVar] by a [GroupVar] to form a new [Term].
+        fn mul(self, rhs: GroupVar) -> Term {
+            rhs * self
+        }
     }
-}
 
-impl Add<Term> for Term {
-    type Output = LinearCombination;
+    impl<Rhs: Clone, Lhs: Mul<Rhs>> Mul<Rhs> for Sum<Lhs> {
+        type Output = Sum<<Lhs as Mul<Rhs>>::Output>;
 
-    fn add(self, rhs: Term) -> LinearCombination {
-        LinearCombination::from(self) + rhs
+        /// Multiplication of the sum by a term, implemented as a general distributive property.
+        fn mul(self, rhs: Rhs) -> Self::Output {
+            Sum(self.0.into_iter().map(|x| x * rhs.clone()).collect())
+        }
     }
-}
 
-impl Mul<ScalarVar> for GroupVar {
-    type Output = Term;
+    // NOTE: Rust forbids implementation of foreign traits (e.g. Mul) over bare generic types (e.g. F:
+    // Field). It can be implemented over specific types (e.g. curve25519_dalek::Scalar or u64). As a
+    // result, this generic implements `var * scalar`, but not `scalar * var`.
 
-    fn mul(self, rhs: ScalarVar) -> Term {
-        Term {
-            elem: self,
-            scalar: rhs,
+    macro_rules! impl_scalar_mul_term {
+        ($($type:ty),+) => {
+            $(
+            impl<F: Field> Mul<F> for $type {
+                type Output = Weighted<$type, F>;
+
+                fn mul(self, rhs: F) -> Self::Output {
+                    Weighted {
+                        term: self,
+                        weight: rhs,
+                    }
+                }
+            }
+            )+
+        };
+    }
+
+    impl_scalar_mul_term!(ScalarVar, GroupVar, Term);
+
+    impl<T, F: Field> Mul<F> for Weighted<T, F> {
+        type Output = Weighted<T, F>;
+
+        fn mul(self, rhs: F) -> Self::Output {
+            Weighted {
+                term: self.term,
+                weight: self.weight * rhs,
+            }
+        }
+    }
+
+    impl<F: Field> Mul<ScalarVar> for Weighted<GroupVar, F> {
+        type Output = Weighted<Term, F>;
+
+        fn mul(self, rhs: ScalarVar) -> Self::Output {
+            Weighted {
+                term: self.term * rhs,
+                weight: self.weight,
+            }
+        }
+    }
+
+    impl<F: Field> Mul<Weighted<GroupVar, F>> for ScalarVar {
+        type Output = Weighted<Term, F>;
+
+        fn mul(self, rhs: Weighted<GroupVar, F>) -> Self::Output {
+            rhs * self
+        }
+    }
+
+    impl<F: Field> Mul<GroupVar> for Weighted<ScalarVar, F> {
+        type Output = Weighted<Term, F>;
+
+        fn mul(self, rhs: GroupVar) -> Self::Output {
+            Weighted {
+                term: self.term * rhs,
+                weight: self.weight,
+            }
+        }
+    }
+
+    impl<F: Field> Mul<Weighted<ScalarVar, F>> for GroupVar {
+        type Output = Weighted<Term, F>;
+
+        fn mul(self, rhs: Weighted<ScalarVar, F>) -> Self::Output {
+            rhs * self
         }
     }
 }
 
-impl Mul<GroupVar> for ScalarVar {
-    type Output = Term;
+mod neg {
+    use super::*;
 
-    fn mul(self, rhs: GroupVar) -> Term {
-        rhs * self
+    impl<T: Neg> Neg for Sum<T> {
+        type Output = Sum<<T as Neg>::Output>;
+
+        /// Negation a sum, implemented as a general distributive property.
+        fn neg(self) -> Self::Output {
+            Sum(self.0.into_iter().map(|x| x.neg()).collect())
+        }
     }
+
+    impl<T, F: Field> Neg for Weighted<T, F> {
+        type Output = Weighted<T, F>;
+
+        /// Negation of a weighted term, implemented as negation of its weight.
+        fn neg(self) -> Self::Output {
+            Weighted {
+                term: self.term,
+                weight: -self.weight,
+            }
+        }
+    }
+
+    // TODO: Find a way to negate ScalarVar, GroupVar, and Term. One option would be to make these
+    // types generic, such that they carry with them what type they can be multiplied by. Another
+    // option is to add a Negated struct, that acts like weighted by specifically for negative one
+    // (and without the requirement that the field by known at that point).
+}
+
+mod sub {
+    use super::*;
+
+    impl<T, Rhs> Sub<Rhs> for Sum<T>
+    where
+        Rhs: Neg,
+        <Rhs as Neg>::Output: Add<Self>,
+    {
+        type Output = <<Rhs as Neg>::Output as Add<Self>>::Output;
+
+        #[allow(clippy::suspicious_arithmetic_impl)]
+        fn sub(self, rhs: Rhs) -> Self::Output {
+            rhs.neg() + self
+        }
+    }
+
+    impl<T, F, Rhs> Sub<Rhs> for Weighted<T, F>
+    where
+        Rhs: Neg,
+        <Rhs as Neg>::Output: Add<Self>,
+    {
+        type Output = <<Rhs as Neg>::Output as Add<Self>>::Output;
+
+        #[allow(clippy::suspicious_arithmetic_impl)]
+        fn sub(self, rhs: Rhs) -> Self::Output {
+            rhs.neg() + self
+        }
+    }
+
+    // TODO: Add additionall impls
 }


### PR DESCRIPTION
This is a work-in-progress implementation of scalar multiplication, negation, and subtraction for group and scalar variables. It introduces a `Weighted<Var>` wrapper that applies a (public) scalar weight to the variable or term. The `LinearMap` is the redefined as a sum of weighted terms. This allows for scalar multiplication of variables and terms, as well as negation implementated as application of a weight of -1.

Note that if we knew all of the group element values at the time of applying the weights, it would be sufficient to multiply those elements. However, we do not and so must operate symbolically.

One challenge that arises is to still generate the "standard" serialization of the linear relation, currently implemented by the label function. This PR includes an implementation that accomplishes this by remapping the weighted group vars to new indices such that each (group var, weight) pair has its own index. When generating the elements (not yet implemented) the value at each index will be equal to (weight * group_elem).

This PR is currently missing most of the `Neg` impls, due to some difficulties around generics.

- **wip on supporting scalar mul, sub, and neg ops**
- **add note and mildly simplify From impls for Sum**
- **wip on creating the standard repr**
- **reimplement the label function**
