### PR TITLE
Add Neg and Sub imples for ScalarVar, GroupVar, and Term

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -8,8 +8,6 @@
 //! - Mismatched parameters during batch verification.
 //! - Uninitialized group variables.
 
-use crate::linear_relation::GroupVar;
-
 /// An error during proving or verification, such as a verification failure.
 #[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
@@ -21,6 +19,6 @@ pub enum Error {
     #[error("Mismatched parameter sizes for batch verification.")]
     ProofSizeMismatch,
     /// Uninitialized group element variable.
-    #[error("Uninitialized group element variable {var:?}")]
-    UnassignedGroupVar { var: GroupVar },
+    #[error("Uninitialized group element variable: {var_debug}")]
+    UnassignedGroupVar { var_debug: String },
 }

--- a/src/linear_relation/mod.rs
+++ b/src/linear_relation/mod.rs
@@ -67,7 +67,6 @@ impl<G: Group> From<(ScalarVar<G>, GroupVar<G>)> for Weighted<Term<G>, G::Scalar
     }
 }
 
-// TODO: Should this be generic over the field instead of the group?
 #[derive(Copy, Clone, Debug)]
 pub struct Weighted<T, F> {
     pub term: T,

--- a/src/linear_relation/mod.rs
+++ b/src/linear_relation/mod.rs
@@ -49,7 +49,7 @@ impl<G> GroupVar<G> {
 }
 
 /// A term in a linear combination, representing `scalar * elem`.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Term<G> {
     scalar: ScalarVar<G>,
     elem: GroupVar<G>,

--- a/src/linear_relation/ops.rs
+++ b/src/linear_relation/ops.rs
@@ -752,7 +752,7 @@ mod tests {
             assert_eq!(expr.terms()[i].term.elem, groups[i]);
             assert_eq!(expr.terms()[i].weight, Scalar::ONE);
         }
-        
+
         assert_eq!(expr.terms()[3].term.scalar, scalars[3]);
         assert_eq!(expr.terms()[3].term.elem, groups[3]);
         assert_eq!(expr.terms()[3].weight, -Scalar::ONE);


### PR DESCRIPTION
This PR adds `Neg` and `Sub` impls for `ScalarVar`, `GroupVar`, and `Term`. Also PR also adds a number of tests, and fixes some missing implementations that were found when implementing these tests.

In order to allow this implementation, this PR adds a generic parameter G to the variable and term types.
