### PR TITLE
Introduce ScalarTerm struct to support Add<Scalar> for ScalarVar and Add<GroupVar> for Term

### DIFF
--- a/src/linear_relation/convert.rs
+++ b/src/linear_relation/convert.rs
@@ -9,6 +9,31 @@ impl<G> From<ScalarVar<G>> for ScalarTerm<G> {
     }
 }
 
+impl<G: Group> From<ScalarVar<G>> for Weighted<ScalarTerm<G>, G::Scalar> {
+    fn from(value: ScalarVar<G>) -> Self {
+        ScalarTerm::from(value).into()
+    }
+}
+
+impl<G: Group> From<Weighted<ScalarVar<G>, G::Scalar>> for Weighted<ScalarTerm<G>, G::Scalar> {
+    fn from(value: Weighted<ScalarVar<G>, G::Scalar>) -> Self {
+        Self {
+            term: value.term.into(),
+            weight: value.weight,
+        }
+    }
+}
+
+// NOTE: Rust does not accept an impl over From<G::Scalar>
+impl<T: Field + Into<G::Scalar>, G: Group> From<T> for Weighted<ScalarTerm<G>, G::Scalar> {
+    fn from(value: T) -> Self {
+        Self {
+            term: ScalarTerm::Unit,
+            weight: value.into(),
+        }
+    }
+}
+
 impl<G> From<(ScalarVar<G>, GroupVar<G>)> for Term<G> {
     fn from((scalar, elem): (ScalarVar<G>, GroupVar<G>)) -> Self {
         Self {
@@ -24,6 +49,15 @@ impl<G> From<(ScalarTerm<G>, GroupVar<G>)> for Term<G> {
     }
 }
 
+impl<G> From<GroupVar<G>> for Term<G> {
+    fn from(value: GroupVar<G>) -> Self {
+        Term {
+            scalar: ScalarTerm::Unit,
+            elem: value,
+        }
+    }
+}
+
 impl<G: Group> From<(ScalarVar<G>, GroupVar<G>)> for Weighted<Term<G>, G::Scalar> {
     fn from(pair: (ScalarVar<G>, GroupVar<G>)) -> Self {
         Term::from(pair).into()
@@ -33,6 +67,21 @@ impl<G: Group> From<(ScalarVar<G>, GroupVar<G>)> for Weighted<Term<G>, G::Scalar
 impl<G: Group> From<(ScalarTerm<G>, GroupVar<G>)> for Weighted<Term<G>, G::Scalar> {
     fn from(pair: (ScalarTerm<G>, GroupVar<G>)) -> Self {
         Term::from(pair).into()
+    }
+}
+
+impl<G: Group> From<GroupVar<G>> for Weighted<Term<G>, G::Scalar> {
+    fn from(value: GroupVar<G>) -> Self {
+        Term::from(value).into()
+    }
+}
+
+impl<G: Group> From<Weighted<GroupVar<G>, G::Scalar>> for Weighted<Term<G>, G::Scalar> {
+    fn from(value: Weighted<GroupVar<G>, G::Scalar>) -> Self {
+        Weighted {
+            term: value.term.into(),
+            weight: value.weight,
+        }
     }
 }
 

--- a/src/linear_relation/convert.rs
+++ b/src/linear_relation/convert.rs
@@ -1,0 +1,93 @@
+use ff::Field;
+use group::Group;
+
+use super::{GroupVar, ScalarTerm, ScalarVar, Sum, Term, Weighted};
+
+impl<G> From<ScalarVar<G>> for ScalarTerm<G> {
+    fn from(value: ScalarVar<G>) -> Self {
+        Self::Var(value)
+    }
+}
+
+impl<G> From<(ScalarVar<G>, GroupVar<G>)> for Term<G> {
+    fn from((scalar, elem): (ScalarVar<G>, GroupVar<G>)) -> Self {
+        Self {
+            scalar: scalar.into(),
+            elem,
+        }
+    }
+}
+
+impl<G> From<(ScalarTerm<G>, GroupVar<G>)> for Term<G> {
+    fn from((scalar, elem): (ScalarTerm<G>, GroupVar<G>)) -> Self {
+        Self { scalar, elem }
+    }
+}
+
+impl<G: Group> From<(ScalarVar<G>, GroupVar<G>)> for Weighted<Term<G>, G::Scalar> {
+    fn from(pair: (ScalarVar<G>, GroupVar<G>)) -> Self {
+        Term::from(pair).into()
+    }
+}
+
+impl<G: Group> From<(ScalarTerm<G>, GroupVar<G>)> for Weighted<Term<G>, G::Scalar> {
+    fn from(pair: (ScalarTerm<G>, GroupVar<G>)) -> Self {
+        Term::from(pair).into()
+    }
+}
+
+impl<T, F: Field> From<T> for Weighted<T, F> {
+    fn from(term: T) -> Self {
+        Self {
+            term,
+            weight: F::ONE,
+        }
+    }
+}
+
+// NOTE: This is implemented directly for each of the key types to avoid collision with the blanket
+// Into impl provided by the standard library.
+macro_rules! impl_from_for_sum {
+    ($($type:ty),+) => {
+        $(
+        impl<G: Group, T: Into<$type>> From<T> for Sum<$type> {
+            fn from(value: T) -> Self {
+                Sum(vec![value.into()])
+            }
+        }
+
+        impl<G: Group, T: Into<$type>> From<Vec<T>> for Sum<$type> {
+            fn from(terms: Vec<T>) -> Self {
+                Self::from_iter(terms)
+            }
+        }
+
+        impl<G: Group, T: Into<$type>, const N: usize> From<[T; N]> for Sum<$type> {
+            fn from(terms: [T; N]) -> Self {
+                Self::from_iter(terms)
+            }
+        }
+
+        impl<G: Group, T: Into<$type>> FromIterator<T> for Sum<$type> {
+            fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+                Self(iter.into_iter().map(|x| x.into()).collect())
+            }
+        }
+        )+
+    };
+}
+
+impl_from_for_sum!(
+    ScalarVar<G>,
+    GroupVar<G>,
+    Term<G>,
+    Weighted<ScalarVar<G>, G::Scalar>,
+    Weighted<GroupVar<G>, G::Scalar>,
+    Weighted<Term<G>, G::Scalar>
+);
+
+impl<T, F: Field> From<Sum<T>> for Sum<Weighted<T, F>> {
+    fn from(sum: Sum<T>) -> Self {
+        Self(sum.0.into_iter().map(|x| x.into()).collect())
+    }
+}

--- a/src/linear_relation/mod.rs
+++ b/src/linear_relation/mod.rs
@@ -562,6 +562,12 @@ where
         // Dump the group elements.
         // XXX. We should return an error if the group elements are not assigned, instead of panicking.
         // Also, batch serialization of group elements should not require allocation of a new vector in this case and should be part of a Group trait.
+        // TODO: This does not result in a complete serialization in that it will contain fewer
+        // elements than the number of indices committed above in the presence of non-unit
+        // weights. This is because the standard_repr function will have allocated a new index for
+        // each unique (index, weight) pair in the original statement, and the associated group
+        // element should be the value of the group element from this map times the weight. That is
+        // currently missing.
         let group_elements = self
             .linear_map
             .group_elements

--- a/src/linear_relation/mod.rs
+++ b/src/linear_relation/mod.rs
@@ -8,7 +8,8 @@
 //! - [`LinearMap`]: a collection of linear combinations acting on group elements.
 //! - [`LinearRelation`]: a higher-level structure managing morphisms and their associated images.
 
-use std::collections::BTreeMap;
+use std::collections::HashMap;
+use std::hash::Hash;
 use std::iter;
 use std::marker::PhantomData;
 
@@ -18,16 +19,17 @@ use group::{Group, GroupEncoding};
 use crate::codec::ShakeCodec;
 use crate::errors::Error;
 use crate::schnorr_protocol::SchnorrProof;
-use crate::serialization::serialize_elements;
 use crate::NISigmaProtocol;
 
+/// Implementations of conversion operations such as From and FromIterator for var and term types.
+mod convert;
 /// Implementations of core ops for the linear combination types.
 mod ops;
 
 /// A wrapper representing an index for a scalar variable.
 ///
 /// Used to reference scalars in sparse linear combinations.
-#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct ScalarVar<G>(usize, PhantomData<G>);
 
 impl<G> ScalarVar<G> {
@@ -36,10 +38,16 @@ impl<G> ScalarVar<G> {
     }
 }
 
+impl<G> Hash for ScalarVar<G> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.hash(state)
+    }
+}
+
 /// A wrapper representing an index for a group element (point).
 ///
 /// Used to reference group elements in sparse linear combinations.
-#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct GroupVar<G>(usize, PhantomData<G>);
 
 impl<G> GroupVar<G> {
@@ -48,38 +56,40 @@ impl<G> GroupVar<G> {
     }
 }
 
+impl<G> Hash for GroupVar<G> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.hash(state)
+    }
+}
+
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
+pub enum ScalarTerm<G> {
+    Var(ScalarVar<G>),
+    Unit,
+}
+
+impl<G: Group> ScalarTerm<G> {
+    // NOTE: This function is private intentionally as it would be replaced if a ScalarMap struct
+    // were to be added.
+    fn value(self, scalars: &[G::Scalar]) -> G::Scalar {
+        match self {
+            Self::Var(var) => scalars[var.0],
+            Self::Unit => G::Scalar::ONE,
+        }
+    }
+}
+
 /// A term in a linear combination, representing `scalar * elem`.
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Term<G> {
-    scalar: ScalarVar<G>,
+    scalar: ScalarTerm<G>,
     elem: GroupVar<G>,
-}
-
-impl<G> From<(ScalarVar<G>, GroupVar<G>)> for Term<G> {
-    fn from((scalar, elem): (ScalarVar<G>, GroupVar<G>)) -> Self {
-        Self { scalar, elem }
-    }
-}
-
-impl<G: Group> From<(ScalarVar<G>, GroupVar<G>)> for Weighted<Term<G>, G::Scalar> {
-    fn from(pair: (ScalarVar<G>, GroupVar<G>)) -> Self {
-        Term::from(pair).into()
-    }
 }
 
 #[derive(Copy, Clone, Debug)]
 pub struct Weighted<T, F> {
     pub term: T,
     pub weight: F,
-}
-
-impl<T, F: Field> From<T> for Weighted<T, F> {
-    fn from(term: T) -> Self {
-        Self {
-            term,
-            weight: F::ONE,
-        }
-    }
 }
 
 #[derive(Clone, Debug)]
@@ -89,53 +99,6 @@ impl<T> Sum<T> {
     /// Access the terms of the sum as slice reference.
     pub fn terms(&self) -> &[T] {
         &self.0
-    }
-}
-
-// NOTE: This is implemented directly for each of the key types to avoid collision with the blanket
-// Into impl provided by the standard library.
-macro_rules! impl_from_for_sum {
-    ($($type:ty),+) => {
-        $(
-        impl<G: Group, T: Into<$type>> From<T> for Sum<$type> {
-            fn from(value: T) -> Self {
-                Sum(vec![value.into()])
-            }
-        }
-
-        impl<G: Group, T: Into<$type>> From<Vec<T>> for Sum<$type> {
-            fn from(terms: Vec<T>) -> Self {
-                Self::from_iter(terms)
-            }
-        }
-
-        impl<G: Group, T: Into<$type>, const N: usize> From<[T; N]> for Sum<$type> {
-            fn from(terms: [T; N]) -> Self {
-                Self::from_iter(terms)
-            }
-        }
-
-        impl<G: Group, T: Into<$type>> FromIterator<T> for Sum<$type> {
-            fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
-                Self(iter.into_iter().map(|x| x.into()).collect())
-            }
-        }
-        )+
-    };
-}
-
-impl_from_for_sum!(
-    ScalarVar<G>,
-    GroupVar<G>,
-    Term<G>,
-    Weighted<ScalarVar<G>, G::Scalar>,
-    Weighted<GroupVar<G>, G::Scalar>,
-    Weighted<Term<G>, G::Scalar>
-);
-
-impl<T, F: Field> From<Sum<T>> for Sum<Weighted<T, F>> {
-    fn from(sum: Sum<T>) -> Self {
-        Self(sum.0.into_iter().map(|x| x.into()).collect())
     }
 }
 
@@ -320,7 +283,7 @@ impl<G: Group> LinearMap<G> {
                 // weight is most commonly 1, but multiplication is constant time.
                 let weighted_coefficients =
                     lc.0.iter()
-                        .map(|weighted| scalars[weighted.term.scalar.0] * weighted.weight)
+                        .map(|weighted| weighted.term.scalar.value(scalars) * weighted.weight)
                         .collect::<Vec<_>>();
                 let elements =
                     lc.0.iter()
@@ -351,6 +314,89 @@ where
     pub image: Vec<GroupVar<G>>,
 }
 
+/// A normalized form of the [LinearRelation], which is used for serialization into the transcript.
+// NOTE: This is not intended to be exposed beyond this module.
+#[derive(Clone)]
+struct LinearRelationRepr<G: GroupEncoding> {
+    constraints: Vec<(u32, Vec<(u32, u32)>)>,
+    group_elements: Vec<G::Repr>,
+}
+
+impl<G: GroupEncoding> Default for LinearRelationRepr<G> {
+    fn default() -> Self {
+        Self {
+            constraints: Default::default(),
+            group_elements: Default::default(),
+        }
+    }
+}
+
+// A utility struct used to build the LinearRelationRepr.
+#[derive(Clone)]
+struct LinearRelationReprBuilder<G: Group + GroupEncoding> {
+    repr: LinearRelationRepr<G>,
+    /// Mapping from the serialized group representation to its index in the repr.
+    /// Acts as a reverse index into the group_elements.
+    group_repr_mapping: HashMap<Box<[u8]>, u32>,
+    /// A mapping from GroupVar index and weight to repr index, to avoid recomputing the scalar mul
+    /// of the group element multiple times.
+    weighted_group_cache: HashMap<GroupVar<G>, Vec<(G::Scalar, u32)>>,
+}
+
+impl<G: Group + GroupEncoding> Default for LinearRelationReprBuilder<G> {
+    fn default() -> Self {
+        Self {
+            repr: Default::default(),
+            group_repr_mapping: Default::default(),
+            weighted_group_cache: Default::default(),
+        }
+    }
+}
+
+impl<G: Group + GroupEncoding> LinearRelationReprBuilder<G> {
+    fn repr_index(&mut self, elem: &G::Repr) -> u32 {
+        if let Some(index) = self.group_repr_mapping.get(elem.as_ref()) {
+            return *index;
+        }
+
+        let new_index = self.repr.group_elements.len() as u32;
+        self.repr.group_elements.push(*elem);
+        self.group_repr_mapping
+            .insert(elem.as_ref().into(), new_index);
+        new_index
+    }
+
+    fn weighted_group_var_index(&mut self, var: GroupVar<G>, weight: &G::Scalar, elem: &G) -> u32 {
+        let entry = self.weighted_group_cache.entry(var).or_default();
+
+        // If the (weight, group_var) pair is already in the cache, use it.
+        if let Some(index) = entry
+            .iter()
+            .find_map(|(entry_weight, index)| (weight == entry_weight).then_some(index))
+        {
+            return *index;
+        }
+
+        // Compute the scalar mul of the element and the weight, then the representation.
+        let weighted_elem_repr = (*elem * weight).to_bytes();
+        // Lookup or assign the index to the representation.
+        let index = self.repr_index(&weighted_elem_repr);
+
+        // Add the index to the cache.
+        // NOTE: entry is dropped earlier to satisfy borrow-check rules.
+        self.weighted_group_cache
+            .get_mut(&var)
+            .unwrap()
+            .push((*weight, index));
+
+        index
+    }
+
+    fn finalize(self) -> LinearRelationRepr<G> {
+        self.repr
+    }
+}
+
 impl<G> LinearRelation<G>
 where
     G: Group + GroupEncoding,
@@ -361,12 +407,6 @@ where
             linear_map: LinearMap::new(),
             image: Vec::new(),
         }
-    }
-
-    /// Computes the total number of bytes required to serialize all current commitments.
-    pub fn commit_bytes_len(&self) -> usize {
-        let repr_len = <G::Repr as Default>::default().as_ref().len(); // size of encoded point
-        self.linear_map.num_constraints() * repr_len // total size of a commit
     }
 
     /// Adds a new equation to the statement of the form:
@@ -502,7 +542,7 @@ where
             // weight is most commonly 1, but multiplication is constant time.
             let weighted_coefficients =
                 lc.0.iter()
-                    .map(|weighted| scalars[weighted.term.scalar.0] * weighted.weight)
+                    .map(|weighted| weighted.term.scalar.value(scalars) * weighted.weight)
                     .collect::<Vec<_>>();
             let elements =
                 lc.0.iter()
@@ -538,14 +578,15 @@ where
     ///   - Nt × [scalar_index: u32, point_index: u32] term entries
     pub fn label(&self) -> Vec<u8> {
         let mut out = Vec::new();
-        let repr = self.standard_repr();
+        // XXX. We should return an error if the group elements are not assigned, instead of panicking.
+        let repr = self.standard_repr().unwrap();
 
         // 1. Number of equations
-        let ne = repr.len();
+        let ne = repr.constraints.len();
         out.extend_from_slice(&(ne as u32).to_le_bytes());
 
         // 2. Encode each equation
-        for (output_index, constraint) in repr {
+        for (output_index, constraint) in repr.constraints {
             // a. Output point index (LHS)
             out.extend_from_slice(&output_index.to_le_bytes());
 
@@ -560,80 +601,67 @@ where
         }
 
         // Dump the group elements.
-        // XXX. We should return an error if the group elements are not assigned, instead of panicking.
-        // Also, batch serialization of group elements should not require allocation of a new vector in this case and should be part of a Group trait.
-        // TODO: This does not result in a complete serialization in that it will contain fewer
-        // elements than the number of indices committed above in the presence of non-unit
-        // weights. This is because the standard_repr function will have allocated a new index for
-        // each unique (index, weight) pair in the original statement, and the associated group
-        // element should be the value of the group element from this map times the weight. That is
-        // currently missing.
-        let group_elements = self
-            .linear_map
-            .group_elements
-            .iter()
-            .map(|(_, x)| x.cloned())
-            .collect::<Option<Vec<_>>>()
-            .expect("All group elements must be assigned");
-        out.extend(serialize_elements(&group_elements));
+        // TODO batch serialization of group elements should not require allocation of a new vector in this case and should be part of a Group trait.
+        for elem in repr.group_elements {
+            out.extend_from_slice(elem.as_ref());
+        }
 
         out
     }
 
     /// Construct an equivalent linear relation in the standardized form, without weights and with
     /// a single group var on the left-hand side.
-    // NOTE: This function has a complimentary function that generates the Group elements for the
-    // remapped variables by multiplying their values by the assigned weights. This function can be
-    // called before the group elements are known, and when they are known the actual values can be
-    // assigned to the remapped indices.
-    fn standard_repr(&self) -> Vec<(u32, Vec<(u32, u32)>)> {
+    fn standard_repr(&self) -> Result<LinearRelationRepr<G>, Error> {
         assert_eq!(
             self.image.len(),
             self.linear_map.constraints.len(),
             "Number of equations and image variables must match"
         );
 
-        // Create an allocator function to remap each (group_var, weight) pair to a new index.
-        // NOTE: Logically, this is a map of (usize, G::Scalar) => u32. However, Field does not
-        // implement Hash or Ord.
-        let mut remapping = BTreeMap::<usize, Vec<(G::Scalar, u32)>>::new();
-        let mut group_var_remap_index = 0u32;
-        let mut remap_var = |var: GroupVar<G>, weight: G::Scalar| -> u32 {
-            let entry = remapping.entry(var.0).or_default();
-
-            // If the (weight, group_var) pair has already been assigned an index, use it.
-            if let Some(remapped_var) = entry.iter().find_map(|(entry_weight, remapped_var)| {
-                (weight == *entry_weight).then_some(remapped_var)
-            }) {
-                return *remapped_var;
-            }
-
-            // The (weight, group_var) pair has not been assigned an index, assign one now.
-            let remapped_var = group_var_remap_index;
-            entry.push((weight, remapped_var));
-            group_var_remap_index += 1;
-
-            remapped_var
-        };
+        let mut repr_builder = LinearRelationReprBuilder::default();
 
         // Iterate through the constraints, applying to remapping to weighed group variables and
         // casting scalar vars to u32.
-        let mut repr = Vec::new();
         for (image_var, equation) in iter::zip(&self.image, &self.linear_map.constraints) {
-            let eq_repr: Vec<(u32, u32)> = equation
+            // Construct the right-hand side, omitting any terms that no not include a scalar, as
+            // they will be moved to the left-hand side.
+            let rhs: Vec<(u32, u32)> = equation
                 .terms()
                 .iter()
-                .map(|weighted_term| {
-                    (
-                        weighted_term.term.scalar.0 as u32,
-                        remap_var(weighted_term.term.elem, weighted_term.weight),
-                    )
+                .filter_map(|weighted_term| match weighted_term.term.scalar {
+                    ScalarTerm::Var(var) => {
+                        Some((var, weighted_term.term.elem, weighted_term.weight))
+                    }
+                    ScalarTerm::Unit => None,
                 })
-                .collect();
-            repr.push((remap_var(*image_var, G::Scalar::ONE), eq_repr));
+                .map(|(scalar_var, group_var, weight)| {
+                    let group_val = self.linear_map.group_elements.get(group_var)?;
+                    let group_index =
+                        repr_builder.weighted_group_var_index(group_var, &weight, &group_val);
+                    Ok((scalar_var.0 as u32, group_index))
+                })
+                .collect::<Result<_, _>>()?;
+
+            // Construct the left-hand side, subtracting all the terms on the right that don't have
+            // a variable scalar term.
+            let image_val = self.linear_map.group_elements.get(*image_var)?;
+            let lhs_val = equation
+                .terms()
+                .iter()
+                .filter_map(|weighted_term| match weighted_term.term.scalar {
+                    ScalarTerm::Unit => Some((weighted_term.term.elem, weighted_term.weight)),
+                    ScalarTerm::Var(_) => None,
+                })
+                .try_fold(image_val, |sum, (group_var, weight)| {
+                    let group_val = self.linear_map.group_elements.get(group_var)?;
+                    Ok(sum - group_val * weight)
+                })?;
+            let lhs_index = repr_builder.repr_index(&lhs_val.to_bytes());
+
+            repr_builder.repr.constraints.push((lhs_index, rhs));
         }
 
-        repr
+        Ok(repr_builder.finalize())
     }
 
     /// Convert this LinearRelation into a non-interactive zero-knowledge protocol

--- a/src/linear_relation/ops.rs
+++ b/src/linear_relation/ops.rs
@@ -157,7 +157,7 @@ mod mul {
         fn mul(self, rhs: ScalarVar<G>) -> Term<G> {
             Term {
                 elem: self,
-                scalar: rhs,
+                scalar: rhs.into(),
             }
         }
     }
@@ -393,8 +393,14 @@ mod tests {
         let y = scalar_var(1);
         let h = group_var(1);
 
-        let term1 = Term { scalar: x, elem: g };
-        let term2 = Term { scalar: y, elem: h };
+        let term1 = Term {
+            scalar: x.into(),
+            elem: g,
+        };
+        let term2 = Term {
+            scalar: y.into(),
+            elem: h,
+        };
 
         let sum = term1 + term2;
         assert_eq!(sum.terms().len(), 2);
@@ -410,9 +416,9 @@ mod tests {
         let term1 = x * g;
         let term2 = g * x;
 
-        assert_eq!(term1.scalar, x);
+        assert_eq!(term1.scalar, x.into());
         assert_eq!(term1.elem, g);
-        assert_eq!(term2.scalar, x);
+        assert_eq!(term2.scalar, x.into());
         assert_eq!(term2.elem, g);
     }
 
@@ -438,7 +444,10 @@ mod tests {
     fn test_term_coefficient_multiplication() {
         let x = scalar_var(0);
         let g = group_var(0);
-        let term = Term { scalar: x, elem: g };
+        let term = Term {
+            scalar: x.into(),
+            elem: g,
+        };
         let weighted = term * Scalar::from(7u64);
 
         assert_eq!(weighted.term, term);
@@ -467,7 +476,10 @@ mod tests {
     fn test_term_negation() {
         let x = scalar_var(0);
         let g = group_var(0);
-        let term = Term { scalar: x, elem: g };
+        let term = Term {
+            scalar: x.into(),
+            elem: g,
+        };
         let neg_term = -term;
 
         assert_eq!(neg_term.term, term);
@@ -517,8 +529,14 @@ mod tests {
         let y = scalar_var(1);
         let h = group_var(1);
 
-        let term1 = Term { scalar: x, elem: g };
-        let term2 = Term { scalar: y, elem: h };
+        let term1 = Term {
+            scalar: x.into(),
+            elem: g,
+        };
+        let term2 = Term {
+            scalar: y.into(),
+            elem: h,
+        };
 
         let diff = term1 - term2;
         assert_eq!(diff.terms().len(), 2);
@@ -637,7 +655,7 @@ mod tests {
         let weighted_g = g * Scalar::from(5u64);
         let result = x * weighted_g;
 
-        assert_eq!(result.term.scalar, x);
+        assert_eq!(result.term.scalar, x.into());
         assert_eq!(result.term.elem, g);
         assert_eq!(result.weight, Scalar::from(5u64));
     }
@@ -650,7 +668,7 @@ mod tests {
         let weighted_x = x * Scalar::from(3u64);
         let result = weighted_x * g;
 
-        assert_eq!(result.term.scalar, x);
+        assert_eq!(result.term.scalar, x.into());
         assert_eq!(result.term.elem, g);
         assert_eq!(result.weight, Scalar::from(3u64));
     }
@@ -714,9 +732,9 @@ mod tests {
 
         let commitment = x * g + r * h;
         assert_eq!(commitment.terms().len(), 2);
-        assert_eq!(commitment.terms()[0].scalar, x);
+        assert_eq!(commitment.terms()[0].scalar, x.into());
         assert_eq!(commitment.terms()[0].elem, g);
-        assert_eq!(commitment.terms()[1].scalar, r);
+        assert_eq!(commitment.terms()[1].scalar, r.into());
         assert_eq!(commitment.terms()[1].elem, h);
     }
 
@@ -729,10 +747,10 @@ mod tests {
 
         let commitment = x * g * Scalar::from(3u64) + r * h * Scalar::from(2u64);
         assert_eq!(commitment.terms().len(), 2);
-        assert_eq!(commitment.terms()[0].term.scalar, x);
+        assert_eq!(commitment.terms()[0].term.scalar, x.into());
         assert_eq!(commitment.terms()[0].term.elem, g);
         assert_eq!(commitment.terms()[0].weight, Scalar::from(3u64));
-        assert_eq!(commitment.terms()[1].term.scalar, r);
+        assert_eq!(commitment.terms()[1].term.scalar, r.into());
         assert_eq!(commitment.terms()[1].term.elem, h);
         assert_eq!(commitment.terms()[1].weight, Scalar::from(2u64));
     }
@@ -748,12 +766,12 @@ mod tests {
         assert_eq!(expr.terms().len(), 4);
 
         for i in 0..3 {
-            assert_eq!(expr.terms()[i].term.scalar, scalars[i]);
+            assert_eq!(expr.terms()[i].term.scalar, scalars[i].into());
             assert_eq!(expr.terms()[i].term.elem, groups[i]);
             assert_eq!(expr.terms()[i].weight, Scalar::ONE);
         }
 
-        assert_eq!(expr.terms()[3].term.scalar, scalars[3]);
+        assert_eq!(expr.terms()[3].term.scalar, scalars[3].into());
         assert_eq!(expr.terms()[3].term.elem, groups[3]);
         assert_eq!(expr.terms()[3].weight, -Scalar::ONE);
     }
@@ -776,7 +794,7 @@ mod tests {
         let expected_groups = [g, h, k];
 
         for i in 0..3 {
-            assert_eq!(expr.terms()[i].term.scalar, expected_scalars[i]);
+            assert_eq!(expr.terms()[i].term.scalar, expected_scalars[i].into());
             assert_eq!(expr.terms()[i].term.elem, expected_groups[i]);
             assert_eq!(expr.terms()[i].weight, Scalar::from(expected_coeffs[i]));
         }
@@ -796,13 +814,13 @@ mod tests {
         let mixed = basic_sum + weighted_term;
 
         assert_eq!(mixed.terms().len(), 3);
-        assert_eq!(mixed.terms()[0].term.scalar, x);
+        assert_eq!(mixed.terms()[0].term.scalar, x.into());
         assert_eq!(mixed.terms()[0].term.elem, g);
         assert_eq!(mixed.terms()[0].weight, Scalar::ONE);
-        assert_eq!(mixed.terms()[1].term.scalar, y);
+        assert_eq!(mixed.terms()[1].term.scalar, y.into());
         assert_eq!(mixed.terms()[1].term.elem, h);
         assert_eq!(mixed.terms()[1].weight, Scalar::ONE);
-        assert_eq!(mixed.terms()[2].term.scalar, z);
+        assert_eq!(mixed.terms()[2].term.scalar, z.into());
         assert_eq!(mixed.terms()[2].term.elem, k);
         assert_eq!(mixed.terms()[2].weight, Scalar::from(3u64));
     }

--- a/src/linear_relation/ops.rs
+++ b/src/linear_relation/ops.rs
@@ -424,7 +424,7 @@ mod neg {
         };
     }
 
-    impl_neg_term!(ScalarVar<G>, GroupVar<G>, Term<G>);
+    impl_neg_term!(ScalarVar<G>, ScalarTerm<G>, GroupVar<G>, Term<G>);
 }
 
 mod sub {
@@ -475,7 +475,7 @@ mod sub {
         };
     }
 
-    impl_sub_as_neg_add!(ScalarVar<G>, GroupVar<G>, Term<G>);
+    impl_sub_as_neg_add!(ScalarVar<G>, ScalarTerm<G>, GroupVar<G>, Term<G>);
 }
 
 #[cfg(test)]

--- a/src/schnorr_protocol.rs
+++ b/src/schnorr_protocol.rs
@@ -143,7 +143,7 @@ where
 
         let lhs = self.0.linear_map.evaluate(response)?;
         let mut rhs = Vec::new();
-        for (i, g) in commitment.iter().enumerate().take(self.commitment_length()) {
+        for (i, g) in commitment.iter().enumerate() {
             rhs.push({
                 let image_var = self.0.image[i];
                 self.0.linear_map.group_elements.get(image_var)? * challenge + g

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -114,7 +114,6 @@ pub trait SigmaProtocolSimulator: SigmaProtocol {
     ) -> Result<Self::Commitment, Error>;
 
     /// Simulates an entire protocol transcript.
-    #[allow(clippy::type_complexity)] // TODO: Address this warning
     fn simulate_transcript<R: Rng + CryptoRng>(
         &self,
         rng: &mut R,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -108,6 +108,7 @@ pub trait SigmaProtocolSimulator: SigmaProtocol {
     ) -> Result<Self::Commitment, Error>;
 
     /// Simulates an entire protocol transcript.
+    #[allow(clippy::type_complexity)] // TODO: Address this warning
     fn simulate_transcript<R: Rng + CryptoRng>(
         &self,
         rng: &mut R,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -83,6 +83,14 @@ pub trait SigmaProtocol {
     fn instance_label(&self) -> impl AsRef<[u8]>;
 }
 
+
+type Transcript<P> = (
+    <P as SigmaProtocol>::Commitment,
+    <P as SigmaProtocol>::Challenge,
+    <P as SigmaProtocol>::Response,
+);
+
+
 /// A trait defining the behavior of a Sigma protocol for which simulation of transcripts is necessary.
 ///
 /// All Sigma protocols can technically simulate a valid transcript, but this mostly serve to prove the security of the protocol and is not used in the real protocol execution.
@@ -112,5 +120,5 @@ pub trait SigmaProtocolSimulator: SigmaProtocol {
     fn simulate_transcript<R: Rng + CryptoRng>(
         &self,
         rng: &mut R,
-    ) -> Result<(Self::Commitment, Self::Challenge, Self::Response), Error>;
+    ) -> Result<Transcript<Self>, Error>;
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -83,13 +83,11 @@ pub trait SigmaProtocol {
     fn instance_label(&self) -> impl AsRef<[u8]>;
 }
 
-
 type Transcript<P> = (
     <P as SigmaProtocol>::Commitment,
     <P as SigmaProtocol>::Challenge,
     <P as SigmaProtocol>::Response,
 );
-
 
 /// A trait defining the behavior of a Sigma protocol for which simulation of transcripts is necessary.
 ///


### PR DESCRIPTION
This PR is an approach to supporting adding and subtracting terms that do not include a private scalar (e.g. "5" in `(x + Scalar::from(5u64)) * g`).

As part of supporting this, the `ScalarTerm` enum is added, which can be a `Var` or `Unit`, where unit represents the constant `Scalar::ONE` in the proof system.

Supporting this in the `LinearRelation` while being able to map the relation to a standardized form from serialization to Fiat-Shamir posed some difficulty. This PR includes one possible implementation.

Additionally, in the course of writing this PR, I realized that the `LinearRelation::label` function on `main` right now is incorrect, in that if there are any terms with non-unit weight, their value will not be included in the serialization. This PR fixes this issue.
