### PR TITLE
Fix nonlinear relation handling in SchnorrProof

### DIFF
--- a/src/schnorr_protocol.rs
+++ b/src/schnorr_protocol.rs
@@ -324,13 +324,16 @@ where
             return Err(Error::InvalidInstanceWitnessPair);
         }
 
+        let zero_vec = vec![<<G as Group>::Scalar as Field>::ZERO; self.0.linear_map.num_scalars];
+        let zero_image = self.0.linear_map.evaluate(&zero_vec)?;
         let response_image = self.0.linear_map.evaluate(response)?;
         let image = self.0.image()?;
 
         let commitment = response_image
             .iter()
             .zip(&image)
-            .map(|(res, img)| *res - *img * challenge)
+            .zip(&zero_image)
+            .map(|((res, img), z_img)| *res - (*img - *z_img) * challenge)
             .collect::<Vec<_>>();
         Ok(commitment)
     }

--- a/src/schnorr_protocol.rs
+++ b/src/schnorr_protocol.rs
@@ -147,11 +147,13 @@ where
         }
 
         let lhs = self.0.linear_map.evaluate(response)?;
+        let zero_vec = vec![<<G as Group>::Scalar as Field>::ZERO; self.0.linear_map.num_scalars];
+        let zero_image = self.0.linear_map.evaluate(&zero_vec)?;
         let mut rhs = Vec::new();
         for (i, g) in commitment.iter().enumerate() {
             rhs.push({
                 let image_var = self.0.image[i];
-                self.0.linear_map.group_elements.get(image_var)? * challenge + g
+                (self.0.linear_map.group_elements.get(image_var)? - zero_image[i]) * challenge + g
             });
         }
         if lhs == rhs {

--- a/src/tests/test_utils.rs
+++ b/src/tests/test_utils.rs
@@ -1,5 +1,6 @@
 //! Definitions used in tests for this crate.
 
+use ff::Field;
 use group::{Group, GroupEncoding};
 
 use crate::linear_relation::{msm_pr, LinearRelation};
@@ -22,6 +23,27 @@ pub fn discrete_logarithm<G: Group + GroupEncoding>(
     let X = relation.linear_map.group_elements.get(var_X).unwrap();
 
     assert_eq!(X, G::generator() * x);
+    (relation, vec![x])
+}
+
+/// LinearMap for knowledge of a translated discrete logarithm relative to a fixed basepoint.
+#[allow(non_snake_case)]
+pub fn translated_discrete_logarithm<G: Group + GroupEncoding>(
+    x: G::Scalar,
+) -> (LinearRelation<G>, Vec<G::Scalar>) {
+    let mut relation: LinearRelation<G> = LinearRelation::new();
+
+    let var_x = relation.allocate_scalar();
+    let var_G = relation.allocate_element();
+
+    let var_X = relation.allocate_eq((var_x + <<G as Group>::Scalar as Field>::ONE) * var_G);
+
+    relation.set_element(var_G, G::generator());
+    relation.compute_image(&[x]).unwrap();
+
+    let X = relation.linear_map.group_elements.get(var_X).unwrap();
+
+    assert!(vec![X] == relation.linear_map.evaluate(&[x]).unwrap());
     (relation, vec![x])
 }
 

--- a/src/tests/test_utils.rs
+++ b/src/tests/test_utils.rs
@@ -69,6 +69,31 @@ pub fn dleq<G: Group + GroupEncoding>(H: G, x: G::Scalar) -> (LinearRelation<G>,
     (relation, vec![x])
 }
 
+/// LinearMap for knowledge of a translated dleq.
+#[allow(non_snake_case)]
+pub fn translated_dleq<G: Group + GroupEncoding>(
+    H: G,
+    x: G::Scalar,
+) -> (LinearRelation<G>, Vec<G::Scalar>) {
+    let mut relation: LinearRelation<G> = LinearRelation::new();
+
+    let var_x = relation.allocate_scalar();
+    let [var_G, var_H] = relation.allocate_elements();
+
+    let var_X = relation.allocate_eq(var_x * var_G + var_H);
+    let var_Y = relation.allocate_eq(var_x * var_H + var_G);
+
+    relation.set_elements([(var_G, G::generator()), (var_H, H)]);
+    relation.compute_image(&[x]).unwrap();
+
+    let X = relation.linear_map.group_elements.get(var_X).unwrap();
+    let Y = relation.linear_map.group_elements.get(var_Y).unwrap();
+
+    assert_eq!(X, G::generator() * x + H);
+    assert_eq!(Y, H * x + G::generator());
+    (relation, vec![x])
+}
+
 /// LinearMap for knowledge of an opening to a Pederson commitment.
 #[allow(non_snake_case)]
 pub fn pedersen_commitment<G: Group + GroupEncoding>(


### PR DESCRIPTION
I identified additional issues when handling compact proofs with nonlinear relations, specifically for relations of the form C = (x + 1) * B.

Both the simulate_commitment and the verify methods of SchnorrProof were not correctly handling the nonlinear part of the relation.

🔧 Changes in this PR
- Fixed SchnorrProof::simulate_commitment to properly support nonlinear relations.
- Fixed SchnorrProof::verify to correctly account for nonlinear parts in the relation.
- Added a dedicated test for a nonlinear relation.

With these fixes, both simulation and verification now fully support nonlinear relations proofs.