### PR TITLE
Default implementation of MSM for PrimeGroup (naive fallback)

### DIFF
--- a/src/linear_relation/canonical.rs
+++ b/src/linear_relation/canonical.rs
@@ -8,7 +8,7 @@ use subtle::{Choice, ConstantTimeEq};
 
 use super::{GroupMap, GroupVar, LinearCombination, LinearRelation, ScalarTerm, ScalarVar};
 use crate::errors::{Error, InvalidInstance};
-use crate::linear_relation::msm_pr;
+use crate::linear_relation::multi_scalar_mul::VariableMultiScalarMul;
 
 /// A normalized form of the [`LinearRelation`], which is used for serialization into the transcript.
 ///
@@ -62,7 +62,7 @@ impl<G: PrimeGroup> CanonicalLinearRelation<G> {
                     .iter()
                     .map(|(_, group_var)| self.group_elements.get(*group_var).unwrap())
                     .collect::<Vec<_>>();
-                msm_pr(&scalars, &bases)
+                G::msm(&scalars, &bases)
             })
             .collect()
     }

--- a/src/linear_relation/multi_scalar_mul.rs
+++ b/src/linear_relation/multi_scalar_mul.rs
@@ -1,0 +1,32 @@
+use group::prime::PrimeGroup;
+
+pub trait VariableMultiScalarMul {
+    type Scalar;
+    type Point;
+
+    fn msm(scalars: &[Self::Scalar], bases: &[Self::Point]) -> Self;
+}
+
+impl<G: PrimeGroup> VariableMultiScalarMul for G {
+    type Scalar = G::Scalar;
+    type Point = G;
+
+    /// Perform a simple multi-scalar multiplication (MSM) over scalars and points.
+    ///
+    /// Given slices of scalars and corresponding group elements (bases),
+    /// returns the sum of each base multiplied by its scalar coefficient.
+    ///
+    /// # Parameters
+    /// - `scalars`: slice of scalar multipliers.
+    /// - `bases`: slice of group elements to be multiplied by the scalars.
+    ///
+    /// # Returns
+    /// The group element result of the MSM.
+    fn msm(scalars: &[Self::Scalar], bases: &[Self::Point]) -> Self {
+        let mut acc = Self::identity();
+        for (s, p) in scalars.iter().zip(bases.iter()) {
+            acc += *p * s;
+        }
+        acc
+    }
+}

--- a/src/tests/test_relations.rs
+++ b/src/tests/test_relations.rs
@@ -8,7 +8,7 @@ use crate::fiat_shamir::Nizk;
 use crate::linear_relation::CanonicalLinearRelation;
 use crate::schnorr_protocol::SchnorrProof;
 
-use crate::linear_relation::{msm_pr, LinearRelation};
+use crate::linear_relation::{LinearRelation, VariableMultiScalarMul};
 
 /// LinearMap for knowledge of a discrete logarithm relative to a fixed basepoint.
 #[allow(non_snake_case)]
@@ -178,8 +178,8 @@ pub fn pedersen_commitment_dleq<G: PrimeGroup, R: RngCore>(
     let witness = [G::Scalar::random(&mut *rng), G::Scalar::random(&mut *rng)];
     let mut relation = LinearRelation::new();
 
-    let X = msm_pr::<G>(&witness, &[generators[0], generators[1]]);
-    let Y = msm_pr::<G>(&witness, &[generators[2], generators[3]]);
+    let X = G::msm(&witness, &[generators[0], generators[1]]);
+    let Y = G::msm(&witness, &[generators[2], generators[3]]);
 
     let [var_x, var_r] = relation.allocate_scalars();
 


### PR DESCRIPTION
This PR introduces a default implementation of multi-scalar multiplication (MSM) over PrimeGroup, using a simple scalar-by-point accumulation strategy. This fallback implementation ensures that any PrimeGroup can benefit from MSM functionality out-of-the-box, even without a custom-optimized backend.

It also introduces the new VariableMultiScalarMul trait. Groups with optimized MSM implementations (e.g., using Straus or Pippenger) can implement this trait to override the default behavior with more efficient algorithms.

This improves modularity, usability, and performance extensibility across the codebase.

Note:

- This closes issue #13.
- For -D clippy warnings, please refer to PR #71.