### PR TITLE
Support OR composition when all supplied branches are true

### DIFF
--- a/examples/simple_composition.rs
+++ b/examples/simple_composition.rs
@@ -40,9 +40,7 @@ fn create_relation(P1: G, P2: G, Q: G, H: G) -> ComposedRelation<G> {
     rel2.set_element(Q_var, Q);
 
     // Compose into OR protocol
-    let proto1 = ComposedRelation::from(rel1);
-    let proto2 = ComposedRelation::from(rel2);
-    ComposedRelation::Or(vec![proto1, proto2])
+    ComposedRelation::or([rel1.canonical().unwrap(), rel2.canonical().unwrap()])
 }
 
 /// Prove knowledge of one of the witnesses (we know x2 for the DLEQ)

--- a/src/composition.rs
+++ b/src/composition.rs
@@ -285,15 +285,13 @@ impl<G: PrimeGroup + ConstantTimeEq> ComposedRelation<G> {
         let mut result_challenges = Vec::with_capacity(instances.len());
         let mut result_responses = Vec::with_capacity(instances.len());
 
-        let prover_states = prover_state;
-
         let mut witness_challenge = *challenge;
         for ComposedOrProverStateEntry(
             valid_witness,
             _prover_state,
             simulated_challenge,
             _simulated_response,
-        ) in &prover_states
+        ) in &prover_state
         {
             let c = G::Scalar::conditional_select(
                 simulated_challenge,
@@ -310,7 +308,7 @@ impl<G: PrimeGroup + ConstantTimeEq> ComposedRelation<G> {
                 simulated_challenge,
                 simulated_response,
             ),
-        ) in instances.iter().zip(prover_states)
+        ) in instances.iter().zip(prover_state)
         {
             let challenge_i = G::Scalar::conditional_select(
                 &simulated_challenge,

--- a/src/linear_relation/mod.rs
+++ b/src/linear_relation/mod.rs
@@ -532,4 +532,11 @@ impl<G: PrimeGroup> LinearRelation<G> {
     ) -> Result<Nizk<SchnorrProof<G>, Shake128DuplexSponge<G>>, InvalidInstance> {
         Ok(Nizk::new(session_identifier, self.try_into()?))
     }
+
+    /// Construct a [CanonicalLinearRelation] from this generalized linear relation.
+    ///
+    /// The construction may fail if the linear relation is malformed, unsatisfiable, or trivial.
+    pub fn canonical(&self) -> Result<CanonicalLinearRelation<G>, InvalidInstance> {
+        self.try_into()
+    }
 }

--- a/src/tests/test_composition.rs
+++ b/src/tests/test_composition.rs
@@ -89,3 +89,29 @@ fn test_or_one_true() {
         assert!(nizk.verify_compact(&proof_compact_bytes).is_ok());
     }
 }
+
+#[allow(non_snake_case)]
+#[test]
+fn test_or_both_true() {
+    // Test composition of a basic OR protocol, with both of the two witnesses being valid.
+
+    // definitions of the underlying protocols
+    let mut rng = OsRng;
+    let (relation1, witness1) = dleq::<G, _>(&mut rng);
+    let (relation2, witness2) = dleq::<G, _>(&mut rng);
+
+    let or_protocol = ComposedRelation::Or(vec![
+        ComposedRelation::Simple(SchnorrProof(relation1)),
+        ComposedRelation::Simple(SchnorrProof(relation2)),
+    ]);
+
+    let witness = ComposedWitness::or([witness1, witness2]);
+    let nizk = or_protocol.into_nizk(b"test_or_one_true");
+
+    // Batchable and compact proofs
+    let proof_batchable_bytes = nizk.prove_batchable(&witness, &mut OsRng).unwrap();
+    let proof_compact_bytes = nizk.prove_compact(&witness, &mut OsRng).unwrap();
+    // Verify proofs
+    assert!(nizk.verify_batchable(&proof_batchable_bytes).is_ok());
+    assert!(nizk.verify_compact(&proof_compact_bytes).is_ok());
+}

--- a/src/tests/test_composition.rs
+++ b/src/tests/test_composition.rs
@@ -10,7 +10,7 @@ type G = RistrettoPoint;
 
 #[allow(non_snake_case)]
 #[test]
-fn test_composition_correctness() {
+fn test_composition_example() {
     // Composition and verification of proof for the following protocol :
     //
     // And(
@@ -32,30 +32,15 @@ fn test_composition_correctness() {
         .map(|_| <G as Group>::Scalar::random(&mut rng))
         .collect::<Vec<_>>();
     // second layer protocol definitions
-    let or_protocol1 = ComposedRelation::<G>::Or(vec![
-        ComposedRelation::Simple(SchnorrProof(relation1)),
-        ComposedRelation::Simple(SchnorrProof(relation2)),
-    ]);
-    let or_witness1 = ComposedWitness::Or(vec![
-        ComposedWitness::Simple(witness1),
-        ComposedWitness::Simple(wrong_witness2),
-    ]);
+    let or_protocol1 = ComposedRelation::<G>::or([relation1, relation2]);
+    let or_witness1 = ComposedWitness::or([witness1, wrong_witness2]);
 
-    let simple_protocol1 = ComposedRelation::Simple(SchnorrProof(relation3));
-    let simple_witness1 = ComposedWitness::Simple(witness3);
-
-    let and_protocol1 = ComposedRelation::And(vec![
-        ComposedRelation::Simple(SchnorrProof(relation4)),
-        ComposedRelation::Simple(SchnorrProof(relation5)),
-    ]);
-    let and_witness1 = ComposedWitness::And(vec![
-        ComposedWitness::Simple(witness4),
-        ComposedWitness::Simple(witness5),
-    ]);
+    let and_protocol1 = ComposedRelation::and([relation4, relation5]);
+    let and_witness1 = ComposedWitness::and([witness4, witness5]);
 
     // definition of the final protocol
-    let instance = ComposedRelation::And(vec![or_protocol1, simple_protocol1, and_protocol1]);
-    let witness = ComposedWitness::And(vec![or_witness1, simple_witness1, and_witness1]);
+    let instance = ComposedRelation::and([or_protocol1, relation3.into(), and_protocol1]);
+    let witness = ComposedWitness::and([or_witness1, witness3.into(), and_witness1]);
 
     let nizk = instance.into_nizk(domain_sep);
 
@@ -65,4 +50,42 @@ fn test_composition_correctness() {
     // Verify proofs
     assert!(nizk.verify_batchable(&proof_batchable_bytes).is_ok());
     assert!(nizk.verify_compact(&proof_compact_bytes).is_ok());
+}
+
+#[allow(non_snake_case)]
+#[test]
+fn test_or_one_true() {
+    // Test composition of a basic OR protocol, with one of the two witnesses being valid.
+
+    // definitions of the underlying protocols
+    let mut rng = OsRng;
+    let (relation1, witness1) = dleq::<G, _>(&mut rng);
+    let (relation2, witness2) = dleq::<G, _>(&mut rng);
+
+    let wrong_witness1 = (0..witness1.len())
+        .map(|_| <G as Group>::Scalar::random(&mut rng))
+        .collect::<Vec<_>>();
+    let wrong_witness2 = (0..witness2.len())
+        .map(|_| <G as Group>::Scalar::random(&mut rng))
+        .collect::<Vec<_>>();
+
+    let or_protocol = ComposedRelation::Or(vec![
+        ComposedRelation::Simple(SchnorrProof(relation1)),
+        ComposedRelation::Simple(SchnorrProof(relation2)),
+    ]);
+
+    // Construct two witnesses to the protocol, the first and then the second as the true branch.
+    let witness_or_1 = ComposedWitness::or([witness1, wrong_witness2]);
+    let witness_or_2 = ComposedWitness::or([wrong_witness1, witness2]);
+
+    let nizk = or_protocol.into_nizk(b"test_or_one_true");
+
+    for witness in [witness_or_1, witness_or_2] {
+        // Batchable and compact proofs
+        let proof_batchable_bytes = nizk.prove_batchable(&witness, &mut OsRng).unwrap();
+        let proof_compact_bytes = nizk.prove_compact(&witness, &mut OsRng).unwrap();
+        // Verify proofs
+        assert!(nizk.verify_batchable(&proof_batchable_bytes).is_ok());
+        assert!(nizk.verify_compact(&proof_compact_bytes).is_ok());
+    }
 }

--- a/src/tests/test_validation_criteria.rs
+++ b/src/tests/test_validation_criteria.rs
@@ -408,10 +408,8 @@ mod proof_validation {
         lr2.set_element(eq2, C);
 
         // Create OR composition
-        let or_relation = ComposedRelation::Or(vec![
-            ComposedRelation::from(lr1),
-            ComposedRelation::from(lr2),
-        ]);
+        let or_relation =
+            ComposedRelation::or([lr1.canonical().unwrap(), lr2.canonical().unwrap()]);
         let nizk = or_relation.into_nizk(b"test_or_relation");
 
         // Create a correct witness for branch 1 (C = y*B)


### PR DESCRIPTION
Currently on `main`, proving an OR statement will fail if more than one of the given witnesses is valid.

This PR is support for supporting OR composition proving when more than one of the branches is valid. Support is added by having the `prover_commit_or` select the first valid witness when more than one valid witness is provided.
