### PR TITLE
Fix overflow in pippenger MSM on 32-bit targets

### DIFF
--- a/src/group/msm.rs
+++ b/src/group/msm.rs
@@ -11,7 +11,11 @@ const fn ln_without_floats(a: usize) -> usize {
     } else {
         // log2(a) * ln(2), ensure minimum value of 1
         let result = (usize::BITS - (a - 1).leading_zeros()) as usize * 69 / 100;
-        if result == 0 { 1 } else { result }
+        if result == 0 {
+            1
+        } else {
+            result
+        }
     }
 }
 


### PR DESCRIPTION
This PR bits an error where the constant `64` as the number of bits in a `usize`.

I reproduced this issue by running the following:

Install the WASI target

```
rustup target add wasm32-wasip1
cargo install wasmtime-cli
```

Run the crate's tests in `wasmtime`

```
CARGO_TARGET_WASM32_WASIP1_RUNNER=wasmtime cargo test --target wasm32-wasip1
```

It would be good to add this to CI to run the tests. I can follow-up on that in another PR. Note that in order to run the tests, I did have to remove criterion temporarily. This can be managed their by using the WASI target that supports threads or by using feature flags to only include criterion when needed.