### PR TITLE
simplify batchable transcript serialization

### DIFF
--- a/src/fiat_shamir.rs
+++ b/src/fiat_shamir.rs
@@ -82,15 +82,13 @@ where
         let mut transcript =
             initialize_prover_state(protocol_id, &self.session_id, instance_label.as_ref());
         let (commitment, ip_state) = self.interactive_proof.prover_commit(witness, rng)?;
-        let commitment_bytes = serialize_messages(&commitment);
-        transcript.public_message(commitment_bytes.as_slice());
+        transcript.prover_messages(&commitment);
         let challenge = transcript.verifier_message::<P::Challenge>();
         let response = self
             .interactive_proof
             .prover_response(ip_state, &challenge)?;
-        let mut proof = commitment_bytes;
-        serialize_messages_into(&response, &mut proof);
-        Ok(proof)
+        transcript.prover_messages(&response);
+        Ok(transcript.narg_string().to_vec())
     }
 
     /// Verifies a batchable non-interactive proof.


### PR DESCRIPTION
## Summary
Simplify `prove_batchable` so the batchable proof is built directly through the transcript API instead of manually serializing the commitment bytes and then appending the response.

## Why
The verifier path already uses transcript-native prover message handling. The prover path was doing the same serialization work manually, which made the code noisier without changing the wire format.

## Root Cause
`prove_batchable` serialized commitments into a temporary byte buffer, absorbed those bytes as a public message, then manually appended serialized responses. That duplicated logic already provided by `ProverState::prover_messages` and `ProverState::narg_string`.

## Impact
The batchable proof generation code is smaller and more direct while preserving the existing NARG string format and verifier behavior.

## Validation
- `cargo test spec_vectors -- --nocapture`
- `cargo test`
