### PR TITLE
[codex] avoid proof parsing preallocation from untrusted lengths

### DIFF
--- a/src/composition.rs
+++ b/src/composition.rs
@@ -307,7 +307,7 @@ where
         match tag_bytes[0] {
             TAG_SIMPLE => {
                 let len = read_u32(buf)? as usize;
-                let mut elems = Vec::with_capacity(len);
+                let mut elems = Vec::new();
                 for _ in 0..len {
                     elems.push(G::deserialize_from_narg(buf)?);
                 }
@@ -315,7 +315,7 @@ where
             }
             TAG_AND => {
                 let len = read_u32(buf)? as usize;
-                let mut entries = Vec::with_capacity(len);
+                let mut entries = Vec::new();
                 for _ in 0..len {
                     entries.push(ComposedCommitment::deserialize_from_narg(buf)?);
                 }
@@ -323,7 +323,7 @@ where
             }
             TAG_OR => {
                 let len = read_u32(buf)? as usize;
-                let mut entries = Vec::with_capacity(len);
+                let mut entries = Vec::new();
                 for _ in 0..len {
                     entries.push(ComposedCommitment::deserialize_from_narg(buf)?);
                 }
@@ -331,7 +331,7 @@ where
             }
             TAG_THRESHOLD => {
                 let len = read_u32(buf)? as usize;
-                let mut entries = Vec::with_capacity(len);
+                let mut entries = Vec::new();
                 for _ in 0..len {
                     entries.push(ComposedCommitment::deserialize_from_narg(buf)?);
                 }
@@ -417,7 +417,7 @@ where
         match tag_bytes[0] {
             TAG_SIMPLE => {
                 let len = read_u32(buf)? as usize;
-                let mut elems = Vec::with_capacity(len);
+                let mut elems = Vec::new();
                 for _ in 0..len {
                     elems.push(G::Scalar::deserialize_from_narg(buf)?);
                 }
@@ -425,7 +425,7 @@ where
             }
             TAG_AND => {
                 let len = read_u32(buf)? as usize;
-                let mut entries = Vec::with_capacity(len);
+                let mut entries = Vec::new();
                 for _ in 0..len {
                     entries.push(ComposedResponse::deserialize_from_narg(buf)?);
                 }
@@ -433,12 +433,12 @@ where
             }
             TAG_OR => {
                 let ch_len = read_u32(buf)? as usize;
-                let mut challenges = Vec::with_capacity(ch_len);
+                let mut challenges = Vec::new();
                 for _ in 0..ch_len {
                     challenges.push(G::Scalar::deserialize_from_narg(buf)?);
                 }
                 let resp_len = read_u32(buf)? as usize;
-                let mut responses = Vec::with_capacity(resp_len);
+                let mut responses = Vec::new();
                 for _ in 0..resp_len {
                     responses.push(ComposedResponse::deserialize_from_narg(buf)?);
                 }
@@ -446,12 +446,12 @@ where
             }
             TAG_THRESHOLD => {
                 let ch_len = read_u32(buf)? as usize;
-                let mut challenges = Vec::with_capacity(ch_len);
+                let mut challenges = Vec::new();
                 for _ in 0..ch_len {
                     challenges.push(G::Scalar::deserialize_from_narg(buf)?);
                 }
                 let resp_len = read_u32(buf)? as usize;
-                let mut responses = Vec::with_capacity(resp_len);
+                let mut responses = Vec::new();
                 for _ in 0..resp_len {
                     responses.push(ComposedResponse::deserialize_from_narg(buf)?);
                 }

--- a/src/fiat_shamir.rs
+++ b/src/fiat_shamir.rs
@@ -278,7 +278,7 @@ fn serialize_messages<T: NargSerialize>(messages: &[T]) -> Vec<u8> {
 }
 
 fn deserialize_messages<T: NargDeserialize>(len: usize, buf: &mut &[u8]) -> Result<Vec<T>, Error> {
-    let mut out = Vec::with_capacity(len);
+    let mut out = Vec::new();
     for _ in 0..len {
         out.push(T::deserialize_from_narg(buf).map_err(|_| Error::VerificationFailure)?);
     }


### PR DESCRIPTION
## What changed
This removes parser-side `Vec::with_capacity` reservations that were driven directly by serialized proof lengths during composed proof deserialization.

## Why
Nested attacker-controlled lengths could force large allocations before any semantic validation occurred.

## Impact
Proof parsing preserves the existing format and behavior while avoiding attacker-sized preallocation during deserialization.

## Validation
- `cargo test --test test_composition`