### PR TITLE
check number of challenges in OR proof

### DIFF
--- a/src/composition.rs
+++ b/src/composition.rs
@@ -1308,7 +1308,10 @@ where
                 ComposedCommitment::Or(commitments),
                 ComposedResponse::Or(challenges, responses),
             ) => {
-                if ps.len() != commitments.len() || commitments.len() != responses.len() {
+                if ps.len() != commitments.len()
+                    || commitments.len() != responses.len()
+                    || challenges.len() != ps.len() - 1
+                {
                     return Err(Error::InvalidInstanceWitnessPair);
                 }
                 let last_challenge = *challenge - challenges.iter().sum::<G::Scalar>();


### PR DESCRIPTION
From my understanding, the OR proof composition should check the fact that number of challenges sent by the prover has to be 1 less than the number of relations so that we can compute the last challenge as a verifier. 

The condition above is not enforced here: 

https://github.com/sigma-rs/sigma-proofs/blob/4dc45b8e232c47eacd92c72bb2f3c4b6fb8e1961/src/composition.rs#L1311

If the prover sends n challenges, the following zip would stop after n challenges and ignore the last challenge.
https://github.com/sigma-rs/sigma-proofs/blob/4dc45b8e232c47eacd92c72bb2f3c4b6fb8e1961/src/composition.rs#L1317