### PR TITLE
feat(traits): add StaticSigmaProtocol for type-level protocol identifiers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,3 +83,4 @@ pub(crate) mod schnorr_protocol;
 pub use fiat_shamir::Nizk;
 pub use group::msm::MultiScalarMul;
 pub use linear_relation::LinearRelation;
+pub use traits::StaticSigmaProtocol;

--- a/src/schnorr_protocol.rs
+++ b/src/schnorr_protocol.rs
@@ -6,7 +6,7 @@
 
 use crate::errors::{Error, Result};
 use crate::linear_relation::CanonicalLinearRelation;
-use crate::traits::{ScalarRng, SigmaProtocol, SigmaProtocolSimulator, Transcript};
+use crate::traits::{ScalarRng, SigmaProtocol, SigmaProtocolSimulator, StaticSigmaProtocol, Transcript};
 use crate::{LinearRelation, MultiScalarMul, Nizk};
 use alloc::vec::Vec;
 use itertools::Itertools;
@@ -159,6 +159,16 @@ where
     }
 
     fn protocol_identifier(&self) -> [u8; 64] {
+        protocol_identifier_for_group::<G>()
+    }
+}
+
+impl<G> StaticSigmaProtocol for CanonicalLinearRelation<G>
+where
+    G: PrimeGroup + Encoding<[u8]> + NargSerialize + NargDeserialize + MultiScalarMul,
+    G::Scalar: Encoding<[u8]> + NargSerialize + NargDeserialize + Decoding<[u8]>,
+{
+    fn static_protocol_id() -> [u8; 64] {
         protocol_identifier_for_group::<G>()
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -104,6 +104,22 @@ pub trait SigmaProtocol {
     fn instance_label(&self) -> impl AsRef<[u8]>;
 }
 
+/// A refinement of [`SigmaProtocol`] for protocols whose identifier is purely type-level.
+///
+/// Most concrete protocols (`CanonicalLinearRelation`, etc.) have a `protocol_identifier` that
+/// depends only on the generic group type `G`, not on the instance data. For those, this trait
+/// exposes the same identifier as an associated function (no `&self`), which is required to wire
+/// the protocol into systems that need a static domain separator (e.g. Argus's `InteractiveArgument`).
+///
+/// `ComposedRelation` deliberately does **not** implement this trait because its identifier is
+/// derived at runtime by hashing the sub-protocol identifiers.
+pub trait StaticSigmaProtocol: SigmaProtocol {
+    /// Returns the protocol's 64-byte identifier without requiring an instance.
+    ///
+    /// This must return the same value as `self.protocol_identifier()` for all instances.
+    fn static_protocol_id() -> [u8; 64];
+}
+
 /// A trait defining the behavior of a Sigma protocol for which simulation of transcripts is necessary.
 ///
 /// Every Sigma protocol can be simulated, but in practice, this is primarily used


### PR DESCRIPTION
CanonicalLinearRelation protocol_identifier never uses self — it dispatches purely on the generic group type G. This adds StaticSigmaProtocol, a supertrait of SigmaProtocol exposing the same identifier as an associated function so that external systems like Argus InteractiveArgument can use it as a static domain separator without requiring an instance.

ComposedRelation deliberately does not implement this trait because its identifier is derived at runtime from the sub-protocol graph.