### PR TITLE
docs: confgure docs.rs to show required features and scraped example

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -111,7 +111,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@nightly
-      - run: cargo doc --all-features --no-deps
+      - run: cargo +nightly doc --all-features --no-deps
 
   # Anchor job for branch protection. Point required status checks at this.
   # see: https://github.com/orgs/community/discussions/26822

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ exclude = [".gitignore"]
 
 [package.metadata.docs.rs]
 all-features = true
+cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
 
 [features]
 # Include commonly used curved in default features.
@@ -109,10 +110,12 @@ required-features = ["bls12_381", "std"]
 [[example]]
 name = "schnorr"
 required-features = ["curve25519-dalek", "std"]
+doc-scrape-examples = true
 
 [[example]]
 name = "simple_composition"
 required-features = ["curve25519-dalek", "std"]
+doc-scrape-examples = true
 
 [[bench]]
 name = "msm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ keywords = ["cryptography", "zero-knowledge", "NIZK", "sigma-protocols"]
 description = "A toolkit for auto-generated implementations of Σ-protocols"
 exclude = [".gitignore"]
 
+[package.metadata.docs.rs]
+all-features = true
+
 [features]
 # Include commonly used curved in default features.
 # Increases the default compile times, but makes the crate just-work for most users.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,7 @@
 //! groups, protocols depending on sigma protocols, and other proof systems.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(non_snake_case)]
 #![doc(html_logo_url = "https://mmaker.github.io/sigma-rs/")]
 #![deny(unused_variables)]


### PR DESCRIPTION
This PR enabled the badges on `docs.rs` to show required features (e.g. to provide an implementation of `MultiscalarMul` on `p256` types), and scraped examples (e.g. for `Nizk::prove_batchable` from `examples/schnorr.rs`).

- **add all-features to docs.rs build**
- **add cfg in lib.rs to enable more docs.rs features**
- **add example scraping to show snippets from stand-alone examples**
