### PR TITLE
Revert "chore(deps): update rust crate rand_chacha to 0.10.0 (#159)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1417,7 +1417,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.4",
 ]
 
@@ -1438,16 +1438,6 @@ checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -1775,7 +1765,7 @@ dependencies = [
  "num-traits",
  "p256",
  "rand 0.8.5",
- "rand_chacha 0.10.0",
+ "rand_chacha",
  "rand_core 0.6.4",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ k256 = { version = "0.13", features = ["arithmetic"] }
 libtest-mimic = "0.8.1"
 p256 = { version = "0.13", features = ["arithmetic"] }
 rand = "0.8.5"
-rand_chacha = { version = "0.10.0" }
+rand_chacha = { version = "0.3.1" }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 serde_with = { version = "3.16.1", features = ["hex"] }


### PR DESCRIPTION
This reverts commit 14d5ab992aad7b920b14431b730fff3f93d425fb. `rand_chacha@0.10` uses a newer version of `rand_core` than we can support in this crate at the moment. Blocker to updating `rand_core` is usage of an older version in `cure25519-dalek`
