### PR TITLE
Restore rand flag for backwards compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,12 @@ exclude = [".gitignore"]
 # Include commonly used curved in default features.
 # Increases the default compile times, but makes the crate just-work for most users.
 default = ["std", "bls12_381", "curve25519-dalek", "k256", "p256"]
+# Kept as a no-op for backward compatibility with downstream crates that enabled
+# the former optional rand dependency feature.
+rand = []
 std = [
     "thiserror",
+    "rand",
     "num-bigint/std",
     "num-traits/std",
     "sha3/std",


### PR DESCRIPTION
We have the following incompatibilities with 0.3:
- Missing `rand` feature flag
- The prover rejects long witnesses 
- The `ScalarRng` trait now is bound by `rand_core::RngCore` and (this one breaks compatibility) `rand_core::CryptoRng`.

I address the first one here, but the other two are good to be enforced in my opinion. 
With this patch we should be OK for releasing 0.3.1 