### PR TITLE
ci: add WASMTIME_BACKTRACE_DETAILS=1 to wasm CI job to get more backtrace info

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -92,6 +92,8 @@ jobs:
       - name: Build
         run: cargo build --target wasm32-wasip1 --verbose
       - name: Test
+        env:
+          WASMTIME_BACKTRACE_DETAILS: "1"
         run: cargo test --target wasm32-wasip1 --verbose --no-fail-fast
 
   bench:


### PR DESCRIPTION
This PR adds WASMTIME_BACKTRACE_DETAILS=1 to the `wasm` CI job. This is to help get more info on the occasional `wasm` test failues in the `dudect` test.
