### PR TITLE
fix: reject empty OR compositions without underflow

### DIFF
--- a/src/composition.rs
+++ b/src/composition.rs
@@ -578,6 +578,7 @@ where
 }
 
 type ComposedChallenge<G> = <CanonicalLinearRelation<G> as SigmaProtocol>::Challenge;
+
 fn threshold_x<F: PrimeField>(index: usize) -> F {
     F::from((index + 1) as u64)
 }
@@ -917,7 +918,7 @@ where
     where
         G: ConditionallySelectable,
     {
-        if instances.len() != witnesses.len() {
+        if instances.is_empty() || instances.len() != witnesses.len() {
             return Err(Error::InvalidInstanceWitnessPair);
         }
 
@@ -988,7 +989,7 @@ where
         let mut result_challenges = Vec::with_capacity(instances.len());
         let mut result_responses = Vec::with_capacity(instances.len());
 
-        if instances.len() != prover_state.len() {
+        if instances.is_empty() || instances.len() != prover_state.len() {
             return Err(Error::InvalidInstanceWitnessPair);
         }
 
@@ -1311,7 +1312,7 @@ where
             ) => {
                 if ps.len() != commitments.len()
                     || commitments.len() != responses.len()
-                    || challenges.len() != ps.len() - 1
+                    || ps.len().checked_sub(1) != Some(challenges.len())
                 {
                     return Err(Error::InvalidInstanceWitnessPair);
                 }
@@ -1477,7 +1478,7 @@ where
                 ComposedCommitment::And(commitments)
             }
             (ComposedRelation::Or(ps), ComposedResponse::Or(challenges, rs)) => {
-                if rs.len() != ps.len() || challenges.len() + 1 != ps.len() {
+                if rs.len() != ps.len() || ps.len().checked_sub(1) != Some(challenges.len()) {
                     return Err(Error::InvalidInstanceWitnessPair);
                 }
                 let last_challenge = *challenge - challenges.iter().sum::<G::Scalar>();
@@ -1541,7 +1542,8 @@ where
                 ComposedResponse::And(responses)
             }
             ComposedRelation::Or(ps) => {
-                let challenges = rng.random_scalars_vec::<G>(ps.len()).to_vec();
+                let challenge_count = ps.len().saturating_sub(1);
+                let challenges = rng.random_scalars_vec::<G>(challenge_count).to_vec();
                 let mut responses = Vec::with_capacity(ps.len());
                 for p in ps.iter() {
                     let mut r = p.simulate_response(&mut *rng);
@@ -1619,7 +1621,11 @@ where
                 ))
             }
             ComposedRelation::Or(ps) => {
-                let challenges = rng.random_scalars_vec::<G>(ps.len() - 1);
+                let challenge_count = ps
+                    .len()
+                    .checked_sub(1)
+                    .ok_or(Error::InvalidInstanceWitnessPair)?;
+                let challenges = rng.random_scalars_vec::<G>(challenge_count);
                 let mut responses = Vec::with_capacity(ps.len());
                 for p in ps.iter() {
                     let mut resp = p.simulate_response(&mut *rng);
@@ -1633,7 +1639,7 @@ where
                 let mut commitments = Vec::with_capacity(ps.len());
                 for i in 0..ps.len() {
                     let mut commitment = ps[i].simulate_commitment(
-                        &if i == ps.len() - 1 {
+                        &if i == challenge_count {
                             challenges.iter().fold(G::Scalar::ZERO, |acc, x| acc - x)
                         } else {
                             challenges[i]

--- a/tests/test_composition.rs
+++ b/tests/test_composition.rs
@@ -1,7 +1,13 @@
 use curve25519_dalek::ristretto::RistrettoPoint as G;
 use group::Group;
 
-use sigma_proofs::composition::{ComposedRelation, ComposedWitness};
+use sigma_proofs::composition::{
+    ComposedCommitment, ComposedProverState, ComposedRelation, ComposedResponse, ComposedWitness,
+};
+use sigma_proofs::errors::Error;
+use sigma_proofs::traits::{SigmaProtocol, SigmaProtocolSimulator};
+
+type Scalar = <G as Group>::Scalar;
 
 mod relations;
 pub use relations::*;
@@ -106,6 +112,49 @@ fn test_or_both_true() {
     // Verify proofs
     assert!(nizk.verify_batchable(&proof_batchable_bytes).is_ok());
     assert!(nizk.verify_compact(&proof_compact_bytes).is_ok());
+}
+
+#[test]
+fn empty_or_verifier_rejects_without_panicking() {
+    let relation: ComposedRelation<G> = ComposedRelation::Or(Vec::new());
+    let commitment = vec![ComposedCommitment::<G>::Or(Vec::new())];
+    let response = vec![ComposedResponse::<G>::Or(Vec::new(), Vec::new())];
+
+    assert!(matches!(
+        relation.verifier(&commitment, &Scalar::from(0u64), &response),
+        Err(Error::InvalidInstanceWitnessPair)
+    ));
+}
+
+#[test]
+fn empty_or_simulate_transcript_rejects_without_panicking() {
+    let relation: ComposedRelation<G> = ComposedRelation::Or(Vec::new());
+
+    assert!(matches!(
+        relation.simulate_transcript(&mut rand::thread_rng()),
+        Err(Error::InvalidInstanceWitnessPair)
+    ));
+}
+
+#[test]
+fn empty_or_simulate_response_cannot_form_commitment() {
+    let relation: ComposedRelation<G> = ComposedRelation::Or(Vec::new());
+    let response = relation.simulate_response(&mut rand::thread_rng());
+
+    assert!(matches!(
+        relation.simulate_commitment(&Scalar::from(0u64), &response),
+        Err(Error::InvalidInstanceWitnessPair)
+    ));
+}
+
+#[test]
+fn empty_or_prover_response_rejects_without_panicking() {
+    let relation: ComposedRelation<G> = ComposedRelation::Or(Vec::new());
+
+    assert!(matches!(
+        relation.prover_response(ComposedProverState::Or(Vec::new()), &Scalar::from(0u64)),
+        Err(Error::InvalidInstanceWitnessPair)
+    ));
 }
 
 #[allow(non_snake_case)]


### PR DESCRIPTION
Today, OR challenge count may lead to underflows.

This fixes it, and handles bad relations such as `ComposedRelation::Or(Vec::new())` across verifier, simulator, and prover response.
The OR challenge count is now computed through checked arithmetic, and regression coverage is included in `tests/test_composition.rs`.
