### PR TITLE
Disable big-endian targets in sigma-proofs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,13 @@
 
 extern crate alloc;
 
+#[cfg(target_endian = "big")]
+compile_error!(
+    r#"
+This crate doesn't support big-endian targets.
+"#
+);
+
 pub mod composition;
 pub mod errors;
 pub mod group;


### PR DESCRIPTION
Running clippy on sigma-proofs shows multiple endianness problems:

```
warning: usage of the function `u32::from_le_bytes`
   --> src/composition.rs:242:8
    |
242 |     Ok(u32::from_le_bytes(head.try_into().unwrap()))
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#little_endian_bytes
    = note: `-W clippy::little-endian-bytes` implied by `-W clippy::restriction`
    = help: to override `-W clippy::restriction` add `#[allow(clippy::little_endian_bytes)]`

warning: used `unwrap()` on a `Result` value
   --> src/composition.rs:242:27
    |
242 |     Ok(u32::from_le_bytes(head.try_into().unwrap()))
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: if this value is an `Err`, it will panic
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#unwrap_used
    = note: `-W clippy::unwrap-used` implied by `-W clippy::restriction`
    = help: to override `-W clippy::restriction` add `#[allow(clippy::unwrap_used)]`

warning: `unwrap` used in a function that returns a `Result`
   --> src/composition.rs:242:27
    |
242 |     Ok(u32::from_le_bytes(head.try_into().unwrap()))
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^
    |
note: in this function signature
   --> src/composition.rs:236:33
    |
236 | fn read_u32(buf: &mut &[u8]) -> VerificationResult<u32> {
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^
    = help: consider using the `?` operator or calling the `.map_err()` method
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#unwrap_in_result
    = note: `-W clippy::unwrap-in-result` implied by `-W clippy::restriction`
    = help: to override `-W clippy::restriction` add `#[allow(clippy::unwrap_in_result)]`


warning: usage of the `u32::to_le_bytes` method
   --> src/composition.rs:246:28
    |
246 |     out.extend_from_slice(&(len as u32).to_le_bytes());
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#little_endian_bytes

warning: using a potentially dangerous silent `as` conversion
   --> src/composition.rs:246:28
    |
246 |     out.extend_from_slice(&(len as u32).to_le_bytes());
    |                            ^^^^^^^^^^^^
    |
    = help: consider using a safe wrapper for this conversion
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#as_conversions
    = note: `-W clippy::as-conversions` implied by `-W clippy::restriction`
    = help: to override `-W clippy::restriction` add `#[allow(clippy::as_conversions)]`

warning: indexing may panic
   --> src/composition.rs:303:15
    |
303 |         match tag_bytes[0] {
    |               ^^^^^^^^^^^^
    |
    = help: consider using `.get(n)` or `.get_mut(n)` instead
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#indexing_slicing
    = note: `-W clippy::indexing-slicing` implied by `-W clippy::restriction`
    = help: to override `-W clippy::restriction` add `#[allow(clippy::indexing_slicing)]`

warning: using a potentially dangerous silent `as` conversion
   --> src/composition.rs:305:27
    |
305 |                 let len = read_u32(buf)? as usize;
    |                           ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider using a safe wrapper for this conversion
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#as_conversions


warning: using a potentially dangerous silent `as` conversion
   --> src/composition.rs:321:27
    |
321 |                 let len = read_u32(buf)? as usize;
    |                           ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider using a safe wrapper for this conversion
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#as_conversions


warning: using a potentially dangerous silent `as` conversion
   --> src/composition.rs:329:27
    |
329 |                 let len = read_u32(buf)? as usize;
    |                           ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider using a safe wrapper for this conversion
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#as_conversions


warning: indexing may panic
   --> src/composition.rs:413:15
    |
413 |         match tag_bytes[0] {
    |               ^^^^^^^^^^^^
    |
    = help: consider using `.get(n)` or `.get_mut(n)` instead
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#indexing_slicing

warning: using a potentially dangerous silent `as` conversion
   --> src/composition.rs:415:27
    |
415 |                 let len = read_u32(buf)? as usize;
    |                           ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider using a safe wrapper for this conversion
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#as_conversions


warning: using a potentially dangerous silent `as` conversion
   --> src/composition.rs:423:27
    |
423 |                 let len = read_u32(buf)? as usize;
    |                           ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider using a safe wrapper for this conversion
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#as_conversions


warning: using a potentially dangerous silent `as` conversion
   --> src/composition.rs:431:30
    |
431 |                 let ch_len = read_u32(buf)? as usize;
    |                              ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider using a safe wrapper for this conversion
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#as_conversions

warning: using a potentially dangerous silent `as` conversion
   --> src/composition.rs:436:32
    |
436 |                 let resp_len = read_u32(buf)? as usize;
    |                                ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider using a safe wrapper for this conversion
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#as_conversions


warning: using a potentially dangerous silent `as` conversion
   --> src/composition.rs:444:30
    |
444 |                 let ch_len = read_u32(buf)? as usize;
    |                              ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider using a safe wrapper for this conversion
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#as_conversions


warning: using a potentially dangerous silent `as` conversion
   --> src/composition.rs:449:32
    |
449 |                 let resp_len = read_u32(buf)? as usize;
    |                                ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider using a safe wrapper for this conversion
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#as_conversions


warning: using a potentially dangerous silent `as` conversion
   --> src/composition.rs:582:13
    |
582 |     F::from((index + 1) as u64)
    |             ^^^^^^^^^^^^^^^^^^
    |
    = help: consider using a safe wrapper for this conversion
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#as_conversions

warning: arithmetic operation that can potentially result in unexpected side-effects
   --> src/composition.rs:582:13
    |
582 |     F::from((index + 1) as u64)
    |             ^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#arithmetic_side_effects
    = note: `-W clippy::arithmetic-side-effects` implied by `-W clippy::restriction`
    = help: to override `-W clippy::restriction` add `#[allow(clippy::arithmetic_side_effects)]`


warning: arithmetic operation that can potentially result in unexpected side-effects
   --> src/composition.rs:586:33
    |
586 |     let mut out = vec![F::ZERO; coeffs.len() + 1];
    |                                 ^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#arithmetic_side_effects

warning: arithmetic operation that can potentially result in unexpected side-effects
   --> src/composition.rs:588:9
    |
588 |         out[i] += *coeff * constant;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#arithmetic_side_effects

warning: indexing may panic
   --> src/composition.rs:588:9
    |
588 |         out[i] += *coeff * constant;
    |         ^^^^^^
    |
    = help: consider using `.get(n)` or `.get_mut(n)` instead
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#indexing_slicing

warning: arithmetic operation that can potentially result in unexpected side-effects
   --> src/composition.rs:589:9
    |
589 |         out[i + 1] += *coeff;
    |         ^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#arithmetic_side_effects

warning: indexing may panic
   --> src/composition.rs:589:9
    |
589 |         out[i + 1] += *coeff;
    |         ^^^^^^^^^^
    |
    = help: consider using `.get(n)` or `.get_mut(n)` instead
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#indexing_slicing

warning: arithmetic operation that can potentially result in unexpected side-effects
   --> src/composition.rs:609:13
    |
609 |             denom *= point_i.x - point_j.x;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#arithmetic_side_effects

warning: arithmetic operation that can potentially result in unexpected side-effects
   --> src/composition.rs:610:50
    |
610 |             basis = poly_mul_linear::<F>(&basis, -point_j.x);
    |                                                  ^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#arithmetic_side_effects

warning: arithmetic operation that can potentially result in unexpected side-effects
   --> src/composition.rs:617:21
    |
617 |         let scale = point_i.y * denom_inv.unwrap_or(F::ZERO);
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#arithmetic_side_effects

warning: arithmetic operation that can potentially result in unexpected side-effects
   --> src/composition.rs:619:13
    |
619 |             *coeff += *basis_coeff * scale;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#arithmetic_side_effects

warning: arithmetic operation that can potentially result in unexpected side-effects
   --> src/composition.rs:630:37
    |
630 |         .fold(F::ZERO, |acc, coeff| acc * x + coeff)
    |                                     ^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#arithmetic_side_effects

warning: arithmetic operation that can potentially result in unexpected side-effects
   --> src/composition.rs:643:18
    |
643 |     let degree = total - threshold;
    |                  ^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#arithmetic_side_effects

warning: arithmetic operation that can potentially result in unexpected side-effects
   --> src/composition.rs:648:41
    |
648 |     let mut points = Vec::with_capacity(degree + 1);
    |                                         ^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#arithmetic_side_effects

warning: using a potentially dangerous silent `as` conversion
   --> src/composition.rs:675:5
    |
675 |     sum as usize
    |     ^^^^^^^^^^^^
    |
    = help: consider using a safe wrapper for this conversion
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#as_conversions

warning: indexing may panic
   --> src/composition.rs:713:34
    |
713 |         T::conditional_swap(&mut head[left], &mut tail[0], swap);
    |                                  ^^^^^^^^^^
    |
    = help: consider using `.get(n)` or `.get_mut(n)` instead
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#indexing_slicing

warning: indexing may panic
   --> src/composition.rs:713:51
    |
713 |         T::conditional_swap(&mut head[left], &mut tail[0], swap);
    |                                                   ^^^^^^^
    |
    = help: consider using `.get(n)` or `.get_mut(n)` instead
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#indexing_slicing

warning: indexing may panic
   --> src/composition.rs:716:34
    |
716 |         T::conditional_swap(&mut tail[0], &mut head[right], swap);
    |                                  ^^^^^^^
    |
    = help: consider using `.get(n)` or `.get_mut(n)` instead
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#indexing_slicing

warning: indexing may panic
   --> src/composition.rs:716:48
    |
716 |         T::conditional_swap(&mut tail[0], &mut head[right], swap);
    |                                                ^^^^^^^^^^^
    |
    = help: consider using `.get(n)` or `.get_mut(n)` instead
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#indexing_slicing

warning: indexing into a slice multiple times without an `assert`
   --> src/composition.rs:740:20
    |
740 |         let b = ((!marks[0]) & marks[1]) ^ z;
    |                    ^^^^^^^^    ^^^^^^^^
    |
    = help: consider asserting the length before indexing: `assert!(marks.len() > 1);`
    = note: asserting the length before indexing will elide bounds checks
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#missing_asserts_for_indexing
    = note: `-W clippy::missing-asserts-for-indexing` implied by `-W clippy::restriction`
    = help: to override `-W clippy::restriction` add `#[allow(clippy::missing_asserts_for_indexing)]`

warning: slicing may panic
   --> src/composition.rs:734:18
    |
734 |     for mark in &marks[..half] {
    |                  ^^^^^^^^^^^^^
    |
    = help: consider using `.get(..n)`or `.get_mut(..n)` instead
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#indexing_slicing

warning: arithmetic operation that can potentially result in unexpected side-effects
   --> src/composition.rs:735:9
    |
735 |         m += mark.unwrap_u8() as usize;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#arithmetic_side_effects

warning: using a potentially dangerous silent `as` conversion
   --> src/composition.rs:735:14
    |
735 |         m += mark.unwrap_u8() as usize;
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider using a safe wrapper for this conversion
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#as_conversions

warning: using a potentially dangerous silent `as` conversion
   --> src/composition.rs:739:30
    |
739 |         let z = Choice::from((offset & 1) as u8);
    |                              ^^^^^^^^^^^^^^^^^^
    |
    = help: consider using a safe wrapper for this conversion
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#as_conversions

warning: indexing may panic
   --> src/composition.rs:740:20
    |
740 |         let b = ((!marks[0]) & marks[1]) ^ z;
    |                    ^^^^^^^^
    |
    = help: consider using `.get(n)` or `.get_mut(n)` instead
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#indexing_slicing

warning: indexing may panic
   --> src/composition.rs:740:32
    |
740 |         let b = ((!marks[0]) & marks[1]) ^ z;
    |                                ^^^^^^^^
    |
    = help: consider using `.get(n)` or `.get_mut(n)` instead
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#indexing_slicing

warning: arithmetic operation that can potentially result in unexpected side-effects
   --> src/composition.rs:745:22
    |
745 |     let offset_mod = offset % half;
    |                      ^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#arithmetic_side_effects

warning: slicing may panic
   --> src/composition.rs:746:30
    |
746 |     oroffcompact_points(&mut points[..half], &marks[..half], offset_mod);
    |                              ^^^^^^^^^^^^^^
    |
    = help: consider using `.get(..n)`or `.get_mut(..n)` instead
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#indexing_slicing

warning: slicing may panic
   --> src/composition.rs:746:47
    |
746 |     oroffcompact_points(&mut points[..half], &marks[..half], offset_mod);
    |                                               ^^^^^^^^^^^^^
    |
    = help: consider using `.get(..n)`or `.get_mut(..n)` instead
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#indexing_slicing

warning: arithmetic operation that can potentially result in unexpected side-effects
   --> src/composition.rs:747:29
    |
747 |     let offset_plus_m_mod = (offset + m) % half;
    |                             ^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#arithmetic_side_effects

warning: slicing may panic
   --> src/composition.rs:748:30
    |
748 |     oroffcompact_points(&mut points[half..], &marks[half..], offset_plus_m_mod);
    |                              ^^^^^^^^^^^^^^
    |
    = help: consider using `.get(n..)` or .get_mut(n..)` instead
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#indexing_slicing

warning: slicing may panic
   --> src/composition.rs:748:47
    |
748 |     oroffcompact_points(&mut points[half..], &marks[half..], offset_plus_m_mod);
    |                                               ^^^^^^^^^^^^^
    |
    = help: consider using `.get(n..)` or .get_mut(n..)` instead
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#indexing_slicing

warning: using a potentially dangerous silent `as` conversion
   --> src/composition.rs:750:26
    |
750 |     let s = Choice::from(((offset_mod + m) >= half) as u8) ^ Choice::from((offset >= half) as u8);
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider using a safe wrapper for this conversion
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#as_conversions

warning: arithmetic operation that can potentially result in unexpected side-effects
   --> src/composition.rs:750:27
    |
750 |     let s = Choice::from(((offset_mod + m) >= half) as u8) ^ Choice::from((offset >= half) as u8);
    |                           ^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#arithmetic_side_effects

warning: using a potentially dangerous silent `as` conversion
   --> src/composition.rs:750:75
    |
750 |     let s = Choice::from(((offset_mod + m) >= half) as u8) ^ Choice::from((offset >= half) as u8);
    |                                                                           ^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider using a safe wrapper for this conversion
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#as_conversions

warning: using a potentially dangerous silent `as` conversion
   --> src/composition.rs:752:34
    |
752 |         let b = s ^ Choice::from((i >= offset_plus_m_mod) as u8);
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider using a safe wrapper for this conversion
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#as_conversions

warning: arithmetic operation that can potentially result in unexpected side-effects
   --> src/composition.rs:753:43
    |
753 |         conditional_swap_point(points, i, i + half, b);
    |                                           ^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#arithmetic_side_effects

warning: arithmetic operation that can potentially result in unexpected side-effects
   --> src/composition.rs:764:24
    |
764 |     let n1 = 1usize << (usize::BITS as usize - 1 - n.leading_zeros() as usize);
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#arithmetic_side_effects

warning: using a potentially dangerous silent `as` conversion
   --> src/composition.rs:764:25
    |
764 |     let n1 = 1usize << (usize::BITS as usize - 1 - n.leading_zeros() as usize);
    |                         ^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider using a safe wrapper for this conversion
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#as_conversions

warning: using a potentially dangerous silent `as` conversion
   --> src/composition.rs:764:52
    |
764 |     let n1 = 1usize << (usize::BITS as usize - 1 - n.leading_zeros() as usize);
    |                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider using a safe wrapper for this conversion
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#as_conversions

warning: arithmetic operation that can potentially result in unexpected side-effects
   --> src/composition.rs:765:14
    |
765 |     let n2 = n - n1;
    |              ^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#arithmetic_side_effects

warning: slicing may panic
   --> src/composition.rs:767:18
    |
767 |     for mark in &marks[..n2] {
    |                  ^^^^^^^^^^^
    |
    = help: consider using `.get(..n)`or `.get_mut(..n)` instead
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#indexing_slicing

warning: arithmetic operation that can potentially result in unexpected side-effects
   --> src/composition.rs:768:9
    |
768 |         m += mark.unwrap_u8() as usize;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#arithmetic_side_effects

warning: using a potentially dangerous silent `as` conversion
   --> src/composition.rs:768:14
    |
768 |         m += mark.unwrap_u8() as usize;
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider using a safe wrapper for this conversion
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#as_conversions

warning: slicing may panic
   --> src/composition.rs:772:39
    |
772 |         oblivious_compact_points(&mut points[..n2], &marks[..n2]);
    |                                       ^^^^^^^^^^^^
    |
    = help: consider using `.get(..n)`or `.get_mut(..n)` instead
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#indexing_slicing

warning: slicing may panic
   --> src/composition.rs:772:54
    |
772 |         oblivious_compact_points(&mut points[..n2], &marks[..n2]);
    |                                                      ^^^^^^^^^^^
    |
    = help: consider using `.get(..n)`or `.get_mut(..n)` instead
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#indexing_slicing

warning: slicing may panic
   --> src/composition.rs:774:30
    |
774 |     oroffcompact_points(&mut points[n2..], &marks[n2..], (n1 - n2 + m) % n1);
    |                              ^^^^^^^^^^^^
    |
    = help: consider using `.get(n..)` or .get_mut(n..)` instead
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#indexing_slicing

warning: slicing may panic
   --> src/composition.rs:774:45
    |
774 |     oroffcompact_points(&mut points[n2..], &marks[n2..], (n1 - n2 + m) % n1);
    |                                             ^^^^^^^^^^^
    |
    = help: consider using `.get(n..)` or .get_mut(n..)` instead
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#indexing_slicing

warning: arithmetic operation that can potentially result in unexpected side-effects
   --> src/composition.rs:774:58
    |
774 |     oroffcompact_points(&mut points[n2..], &marks[n2..], (n1 - n2 + m) % n1);
    |                                                          ^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#arithmetic_side_effects

warning: using a potentially dangerous silent `as` conversion
   --> src/composition.rs:777:30
    |
777 |         let b = Choice::from((i >= m) as u8);
    |                              ^^^^^^^^^^^^^^
    |
    = help: consider using a safe wrapper for this conversion
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#as_conversions

warning: arithmetic operation that can potentially result in unexpected side-effects
   --> src/composition.rs:778:43
    |
778 |         conditional_swap_point(points, i, i + n1, b);
    |                                           ^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#arithmetic_side_effects

warning: arithmetic operation that can potentially result in unexpected side-effects
   --> src/composition.rs:831:25
    |
831 |                         count += 1;
    |                         ^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#arithmetic_side_effects

warning: using a potentially dangerous silent `as` conversion
   --> src/composition.rs:834:30
    |
834 |                 Choice::from((count >= *threshold) as u8)
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider using a safe wrapper for this conversion
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#as_conversions

warning: indexing may panic
   --> src/composition.rs:953:33
    |
953 |             let valid_witness = instances[i].is_witness_valid(w) & !valid_witness_found;
    |                                 ^^^^^^^^^^^^
    |
    = help: consider using `.get(n)` or `.get_mut(n)` instead
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#indexing_slicing

warning: arithmetic operation that can potentially result in unexpected side-effects
    --> src/composition.rs:1008:13
     |
1008 |             witness_challenge -= c;
     |             ^^^^^^^^^^^^^^^^^^^^^^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#arithmetic_side_effects

warning: arithmetic operation that can potentially result in unexpected side-effects
    --> src/composition.rs:1065:29
     |
1065 |         let invalid_count = instances.len() - count_choices(&valid_witnesses);
     |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#arithmetic_side_effects

warning: using a potentially dangerous silent `as` conversion
    --> src/composition.rs:1070:35
     |
1070 |         let mut remaining_seeds = (degree - invalid_count) as u32;
     |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = help: consider using a safe wrapper for this conversion
     = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#as_conversions

warning: arithmetic operation that can potentially result in unexpected side-effects
    --> src/composition.rs:1070:35
     |
1070 |         let mut remaining_seeds = (degree - invalid_count) as u32;
     |                                   ^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#arithmetic_side_effects
```

This PR explicitly disables big-endian targets (already disabled in spongefish). `hash2group` is not affected by endianness issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
